### PR TITLE
Hability to handle sentry instances with a non-default port

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -61,7 +61,7 @@ _.process = function process(kwargs) {
     kwargs['timestamp'] = new Date().toISOString().split('.')[0];
     kwargs['project'] = this.dsn.project_id;
     kwargs['site'] = kwargs['site'] || this.site;
-    
+
     // this will happen asynchronously. We don't care about it's response.
     this._enabled && this.send(kwargs);
 
@@ -75,7 +75,13 @@ _.sendRemote = function sendRemote(message, headers, cb) {
         path: self.dsn.path + '/api/store/',
         headers: headers,
         method: 'POST'
-    }, req = http[self.dsn.protocol].request(options, function(res){
+    };
+
+    if (self.dsn.port) {
+        options.port = self.dsn.port;
+        options.host = options.host.split(':')[0];
+    }
+    var req = http[self.dsn.protocol].request(options, function(res){
         res.setEncoding('utf8');
         res.on('data', function(data) {
             // don't care!
@@ -105,7 +111,7 @@ _.send = function send(kwargs) {
                 'Content-Type': 'application/octet-stream',
                 'Content-Length': message.length
             };
-            
+
         self.sendRemote(message, headers);
     });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,6 +34,9 @@ module.exports.parseDSN = function parseDSN(dsn) {
               private_key: parsed.auth.split(':')[1],
               host: parsed.host
           };
+        if (parsed.port) {
+            response.port = parsed.port;
+        }
 
         var path = parsed.path.substr(1),
             index = path.lastIndexOf('/');
@@ -78,7 +81,7 @@ module.exports.parseStackBetter = function parseStackBetter(err, cb) {
     //Error.captureStackTrace(err);
     var lines = err.stack;
     Error.prepareStackTrace = orig;
-    
+
     lines.forEach(function(line, index){
         var frame = {
             function: line.getFunctionName(),
@@ -105,7 +108,7 @@ module.exports.parseStack = function parseStack(stack, cb) {
             callbacks=lines.length,
             frames=[],
             cache={};
-        
+
         if(lines.length === 0) {
             throw new Error('No lines to parse!');
         }


### PR DESCRIPTION
I have a sentry instance with a port that's not 443 and the parsing of the DSN didn't handle the case where the port is non-standard. This fixes it for me.

Thanks,
Bruno
