### PR TITLE
Add a "silent" option for test/development

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -21,12 +21,14 @@ var Client = function Client(dsn, options) {
         dsn = process.env.SENTRY_DSN;
     }
     options = options || {};
-    this.dsn = utils.parseDSN(dsn);
+    this.dsn = utils.parseDSN(dsn, options.silent) || {};
     this.name = options.name || process.env.SENTRY_NAME || require('os').hostname();
     this.site = options.site || process.env.SENTRY_SITE;
     this.root = options.root || process.cwd();
     if(!process.env.NODE_ENV || !(process.env.NODE_ENV == 'production' || process.env.NODE_ENV == 'test')) {
-        console.warn('Warning: Sentry logging is disabled, please set NODE_ENV=production');
+        if (!options.silent) {
+            console.warn('Warning: Sentry logging is disabled, please set NODE_ENV=production');
+        }
         this._enabled = false;
     } else {
         this._enabled = true;
@@ -61,7 +63,7 @@ _.process = function process(kwargs) {
     kwargs['timestamp'] = new Date().toISOString().split('.')[0];
     kwargs['project'] = this.dsn.project_id;
     kwargs['site'] = kwargs['site'] || this.site;
-    
+
     // this will happen asynchronously. We don't care about it's response.
     this._enabled && this.send(kwargs);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,7 +31,7 @@ module.exports.getAuthHeader = function getAuthHeader(signature, timestamp, api_
     return header.join(', ');
 };
 
-module.exports.parseDSN = function parseDSN(dsn) {
+module.exports.parseDSN = function parseDSN(dsn, silent) {
     try {
         var parsed = url.parse(dsn),
             response = {
@@ -54,7 +54,9 @@ module.exports.parseDSN = function parseDSN(dsn) {
         response.port = ~~parsed.port || protocolMap[response.protocol] || 443;
         return response;
     } catch(e) {
-        throw new Error('Invalid Sentry DSN: ' + dsn);
+        if (!silent) {
+            throw new Error('Invalid Sentry DSN: ' + dsn);
+        }
     }
 };
 
@@ -91,7 +93,7 @@ module.exports.parseStackBetter = function parseStackBetter(err, cb) {
     //Error.captureStackTrace(err);
     var lines = err.stack;
     Error.prepareStackTrace = orig;
-    
+
     lines.forEach(function(line, index){
         var frame = {
             function: line.getFunctionName(),
@@ -118,7 +120,7 @@ module.exports.parseStack = function parseStack(stack, cb) {
             callbacks=lines.length,
             frames=[],
             cache={};
-        
+
         if(lines.length === 0) {
             throw new Error('No lines to parse!');
         }

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -85,6 +85,10 @@ describe('raven.Client', function(){
         delete process.env.SENTRY_SITE;
     });
 
+    it('should survive in silent mode with missing DSN', function() {
+        var client = new raven.Client(undefined, { silent: true });
+    });
+
     describe('#getIdent()', function(){
         it('should match', function(){
             var result = {


### PR DESCRIPTION
This change adds a simple "silent" mode, as described by Issue #12 from @zzen.

You simply pass `{ silent: true }` into the Client constructor, and it will swallow two things: The failure to find/parse the DSN (because you have no DSN), and the failure to run in NODE_ENV='production'.  I'm using a dummy dsn object to avoid later failures down the pipe (since `captureMessage`, for instance, returns an object even if it's disabled and I didn't want to change that).

In practice, just add the `{ silent: true }` flag if you're using Raven in a development server or test harness and don't want to see extra log messages appear, and don't want to add extra logic and branching to avoid using it.

Might not be the cleanest implementation, but it gets the job done.
