### PR TITLE
fix wrong API call in patchGlobal

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -134,7 +134,7 @@ module.exports.patchGlobal =
 module.exports.patch_global = function patchGlobal(client) {
     client = (client instanceof Client) ? client : new Client(client);
     process.on('uncaughtException', function(err) {
-        client.captureMessage(err, function(result) {
+        client.captureException(err, function(result) {
             node_util.log('uncaughtException: '+client.get_ident(result));
         });
     });


### PR DESCRIPTION
patchGlobal doesn't work because it is calling a function on the client that isn't existing anymore. This pull requests fixes that bug.
