### PR TITLE
fix for missing frame filename

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -95,8 +95,8 @@ function parseStack(stack, cb) {
 
     stack.forEach(function(line, index) {
         var frame = {
-            filename: line.getFileName(),
-            lineno: line.getLineNumber() || '',
+            filename: line.getFileName() || '',
+            lineno: line.getLineNumber(),
             'function': line.getFunctionName() || '?'
         }, isInternal = line.isNative() ||
                         (frame.filename[0] !== '/' &&


### PR DESCRIPTION
frame.getFileName is not guaranteed to return a value. [According to Google](https://code.google.com/p/v8/wiki/JavaScriptStackTraceApi), it returns a value "if this function was defined in a script".

I'm not sure exactly what this means: it seems to me like a function would always be defined in a script, but apparently that is not the case, because some of my test cases were failing when it was trying to access frame.filename[0] because frame.filename was null.

This line in the stack trace is presumably indicating that it couldn't find the filename: `Error: <the message> at Error (unknown source)`
