### PR TITLE
Clean up error parsing and stack trace peparing

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -11,10 +11,10 @@ module.exports.parseText = function parseText(message, kwargs) {
 module.exports.parseError = function parseError(err, kwargs, cb) {
     Error.prepareStackTrace = function(error, structuredStackTrace) {
         utils.parseStack(structuredStackTrace, function(frames) {
-            kwargs['message'] = err.name + ': ' + (err.message || '<no message>');
+            kwargs['message'] = error.name + ': ' + (error.message || '<no message>');
             kwargs['sentry.interfaces.Exception'] = {
-                type: err.name,
-                value:err.message
+                type: error.name,
+                value:error.message
             };
 
             kwargs['sentry.interfaces.Stacktrace'] = {frames: frames};


### PR DESCRIPTION
Hey Matt,

I was seeing some weird random crashes that I think were related to the way that I changed this code before (sorry!) - basically, sometimes when an exception was thrown that raven tried to catch, that would trigger a crash here. Unfortunately, I wasn't able to reliably produce it so I can't provide a test case.

Changing the way you parse the structured stack trace to this resolved my intermittent crashes.

Long term, it might be worthwhile to either use this or hook into the stack traces the same way that they do: https://github.com/jb55/node-raw-stacktrace. That way you're not overwriting prepareStackTrace every time an error is thrown, but instead only overwrite it once. That would have been a more drastic change, though, so I didn't want to do anything like that without talking to you first.
