### PR TITLE
Minor improvements to the transport library

### DIFF
--- a/lib/transports.js
+++ b/lib/transports.js
@@ -30,7 +30,7 @@ HTTPTransport.prototype.send = function(client, message, headers) {
                 self.emit('logged');
             } else {
                 body = body.join('');
-                var e = new Error('HTTP Error: ' + body);
+                var e = new Error('HTTP Error (' + res.statusCode + '): ' + body);
                 e.response = res;
                 e.statusCode = res.statusCode;
                 e.responseBody = body;


### PR DESCRIPTION
I've fixed som minor stuff in the transport library:
- Hostname is preferred when using http(s).request
- Use default port if none is given in DSN
- Accept all 2xx response codes from the api (e.g. previously it would be considered a failure if 202 was returned)
- Show the status code if an error occurs
