### PR TITLE
Fix dsn.path where Sentry runs at a non-root URL

### DIFF
--- a/lib/transports.js
+++ b/lib/transports.js
@@ -15,7 +15,7 @@ HTTPTransport.prototype.send = function(client, message, headers) {
     var self = client;
     var options = {
         hostname: self.dsn.host,
-        path: self.dsn.path + '/api/store/',
+        path: self.dsn.path + 'api/store/',
         headers: headers,
         method: 'POST',
         port: self.dsn.port || this.defaultPort

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,10 +47,9 @@ module.exports.parseDSN = function parseDSN(dsn) {
             throw new Error('Invalid transport');
         }
 
-        var path = parsed.path.substr(1),
-            index = path.lastIndexOf('/');
-        response.path = path.substr(0, index);
-        response.project_id = ~~path.substr(index+1);
+        var index = parsed.pathname.lastIndexOf('/');
+        response.path = parsed.pathname.substr(0, index+1);
+        response.project_id = ~~parsed.pathname.substr(index+1);
         response.port = ~~parsed.port || protocolMap[response.protocol] || 443;
         return response;
     } catch(e) {

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -39,7 +39,7 @@ describe('raven.Client', function(){
             public_key: 'public',
             private_key: 'private',
             host: 'app.getsentry.com',
-            path: '',
+            path: '/',
             project_id: 269,
             port: 443
         };
@@ -55,7 +55,7 @@ describe('raven.Client', function(){
             public_key: 'abc',
             private_key: '123',
             host: 'app.getsentry.com',
-            path: '',
+            path: '/',
             project_id: 1,
             port: 443
         };
@@ -71,7 +71,7 @@ describe('raven.Client', function(){
             public_key: 'abc',
             private_key: '123',
             host: 'app.getsentry.com',
-            path: '',
+            path: '/',
             project_id: 1,
             port: 443
         };
@@ -286,7 +286,7 @@ describe('raven.Client', function(){
             public_key: 'public',
             private_key: 'private',
             host: 'app.getsentry.com',
-            path: '',
+            path: '/',
             project_id: 269,
             port: 443
         };
@@ -295,4 +295,21 @@ describe('raven.Client', function(){
         client.dsn.should.eql(expected);
         client.transport.should.equal('some_heka_instance');
     });
+
+    it('should use a DSN subpath when sending requests', function(done){
+        var dsn = 'https://public:private@app.getsentry.com/some/path/269';
+        var client = new raven.Client(dsn);
+
+        var scope = nock('https://app.getsentry.com')
+            .filteringRequestBody(/.*/, '*')
+            .post('/some/path/api/store/', '*')
+            .reply(200, 'OK');
+
+        client.on('logged', function(){
+            scope.done();
+            done();
+        });
+        client.captureMessage('Hey!');
+    });
 });
+

--- a/test/raven.utils.js
+++ b/test/raven.utils.js
@@ -23,7 +23,7 @@ describe('raven.utils', function() {
         public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
         private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
         host: 'app.getsentry.com',
-        path: '',
+        path: '/',
         project_id: 269,
         port: 443
       };
@@ -37,7 +37,7 @@ describe('raven.utils', function() {
         public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
         private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
         host: 'mysentry.com',
-        path: 'some/other/path',
+        path: '/some/other/path/',
         project_id: 269,
         port: 80
       };
@@ -51,7 +51,7 @@ describe('raven.utils', function() {
         public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
         private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
         host: 'mysentry.com',
-        path: 'some/other/path',
+        path: '/some/other/path/',
         project_id: 269,
         port: 8443
       };
@@ -70,7 +70,7 @@ describe('raven.utils', function() {
         public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
         private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
         host: 'mysentry.com',
-        path: 'some/other/path',
+        path: '/some/other/path/',
         project_id: 269,
         port: 1234
       };
@@ -90,7 +90,7 @@ describe('raven.utils', function() {
         public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
         private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
         host: 'mysentry.com',
-        path: 'some/other/path',
+        path: '/some/other/path/',
         project_id: 269,
         port: 8443
       };


### PR DESCRIPTION
with a DSN like `https://A:B@host.example.com/sentry/123`, `parseDSN()` ends up like:

```
{ protocol: 'https',
  public_key: 'A',
  private_key: 'B',
  host: 'host.example.com',
  path: 'sentry',
  project_id: 123,
  port: 443 }
```

which means when a request is sent, it goes to `sentry/api/store/` instead of `/sentry/api/store/`.

The change fixes `dsn.path` to be `/sentry` for such URLs, and the existing `''` when sentry is running at the domain root.
