### PR TITLE
Update Express instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ connect(
 
 #### Express
 ```javascript
-var app = require('express').createServer();
+var app = require('express')();
+app.use(app.router);
 app.use(raven.middleware.express('{{ SENTRY_DSN }}'));
 app.use(onError); // optional error handler if you want to display the error id to a user
 app.get('/', function mainHandler(req, res) {


### PR DESCRIPTION
- replace deprecated express `createServer()`
- add `app.use(app.router)`, otherwise the error-handling middleware doesn't get called when errors occur in the routing. eg. [Express 3 error middleware not being called](http://stackoverflow.com/questions/13198129/express-3-error-middleware-not-being-called)
