### PR TITLE
Use new type assertion syntax (should.js ~2.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "connect": "*",
     "express": "*",
     "mocha": "*",
-    "should": "*",
+    "should": "~2.0.1",
     "nock": "*",
     "glob": "*",
     "mock-udp": "*"

--- a/test/raven.parsers.js
+++ b/test/raven.parsers.js
@@ -107,7 +107,7 @@ describe('raven.parsers', function(){
         throw new Error('Derp');
       } catch(e) {
         raven.parsers.parseError(e, {}, function(parsed){
-          e.stack.should.be.a('string')
+          e.stack.should.be.a.String;
           done();
         });
       }


### PR DESCRIPTION
Fixes the broken build. (see comments in #44)

It seems like a good idea to specify vague guidelines for even dev deps for this reason.
