### PR TITLE
use lsmod to capture only top level module info

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var url = require('url');
 var transports = require('./transports');
 var path = require('path');
+var lsmod = require('lsmod');
 
 var protocolMap = {
     'http': 80,
@@ -65,31 +66,11 @@ module.exports.getCulprit = function getCulprit(frame) {
 
 var module_cache;
 module.exports.getModules = function getModules() {
-    if(module_cache) {
+    if (module_cache) {
         return module_cache;
     }
 
-    module_cache = {};
-    require.main.paths.forEach(function(path_dir) {
-        if (!(fs.existsSync || path.existsSync)(path_dir)) {
-            return;
-        }
-
-        var modules = fs.readdirSync(path_dir).filter(function(name) {
-            return name.charAt(0) !== '.';
-        });
-
-        modules.forEach(function(module) {
-            var pkg_json = path.join(path_dir, module, 'package.json');
-
-            try {
-                var json = require(pkg_json);
-                module_cache[json.name] = json.version;
-            } catch(e) {}
-        });
-    });
-
-    return module_cache;
+    return module_cache = lsmod();
 };
 
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "node-uuid": "~1.4.1",
-    "raw-stacktrace": "1.0.0"
+    "raw-stacktrace": "1.0.0",
+    "lsmod": "0.0.2"
   },
   "devDependencies": {
     "connect": "*",


### PR DESCRIPTION
The modules we immediately depend on are the most important to record
for errors. Other modules deeper in the tree will just begin to clutter
the modules list. Since the modules section isn't as useful as things
like the stacktrace in general this pruning of prior module list
behavior will be ok.
