### PR TITLE
don't use self to refer to client from transport

### DIFF
--- a/lib/transports.js
+++ b/lib/transports.js
@@ -12,24 +12,23 @@ function HTTPTransport() {
 }
 util.inherits(HTTPTransport, Transport);
 HTTPTransport.prototype.send = function(client, message, headers) {
-    var self = client;
     var options = {
-        hostname: self.dsn.host,
-        path: self.dsn.path + 'api/store/',
+        hostname: client.dsn.host,
+        path: client.dsn.path + 'api/store/',
         headers: headers,
         method: 'POST',
-        port: self.dsn.port || this.defaultPort
+        port: client.dsn.port || this.defaultPort
     }, req = this.transport.request(options, function(res){
         res.setEncoding('utf8');
         if(res.statusCode >= 200 && res.statusCode < 300) {
-            self.emit('logged');
+            client.emit('logged');
         } else {
             var reason = res.headers['x-sentry-error'];
             var e = new Error('HTTP Error (' + res.statusCode + '): ' + reason);
             e.response = res;
             e.statusCode = res.statusCode;
             e.reason = reason;
-            self.emit('error', e);
+            client.emit('error', e);
         }
         // force the socket to drain
         var noop = function(){};
@@ -37,7 +36,7 @@ HTTPTransport.prototype.send = function(client, message, headers) {
         res.on('end', noop);
     });
     req.on('error', function(e){
-        self.emit('error', e);
+        client.emit('error', e);
     });
     req.end(message);
 }
@@ -55,15 +54,14 @@ function UDPTransport() {
 }
 util.inherits(UDPTransport, Transport);
 UDPTransport.prototype.send = function(client, message, headers) {
-    var self = client;
     message = new Buffer(headers['X-Sentry-Auth'] + '\n\n'+ message);
 
     var udp = dgram.createSocket('udp4');
-    udp.send(message, 0, message.length, self.dsn.port || this.defaultPort, self.dsn.host, function(e, bytes) {
+    udp.send(message, 0, message.length, client.dsn.port || this.defaultPort, client.dsn.host, function(e, bytes) {
         if(e){
-            return self.emit('error', e);
+            return client.emit('error', e);
         }
-        self.emit('logged');
+        client.emit('logged');
         udp.close();
     });
 }


### PR DESCRIPTION
These are artifacts from the transports refactor that moved them out of
the client and into their own classes. It doesn't really make sense to
rename the variable when the scopes of the two are the same. This change
is particularly useful because it's easy to read the code and see that
`self` is emitting events, but then it isn't immediately apparent why
binding to `client.transport` isn't working.
