### PR TITLE
Reverse the stack before sending it to sentry

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -17,7 +17,7 @@ module.exports.parseError = function parseError(err, kwargs, cb) {
         };
         kwargs['sentry.interfaces.Stacktrace'] = {frames: frames};
 
-        for (var n = 0, l = frames.length; n < l; n++) {
+        for (var n = frames.length - 1; n >= 0; n--) {
             if (frames[n].in_app) {
                 kwargs['culprit'] = utils.getCulprit(frames[n]);
                 break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -125,6 +125,9 @@ function parseStack(err, cb) {
 
     var callbacks = stack.length;
 
+    // Sentry requires the stack trace to be from oldest to newest
+    stack.reverse();
+
     stack.forEach(function(line, index) {
         var frame = {
             filename: line.getFileName() || '',


### PR DESCRIPTION
Sentry requires that the stack be sent in order from oldest to newest, the opposite of the stack trace we have.  This should make the stack trace make a lot more sense in the sentry UI.
