### PR TITLE
Added missing semi-colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ It is recommended that you don't leave the process running after receiving an `u
 
 ```javascript
 client.patchGlobal(function() {
-  console.log('Bye, bye, world.')
+  console.log('Bye, bye, world.');
   process.exit(1);
 });
 ```


### PR DESCRIPTION
Not strictly needed, but convention seems to be in the rest of the readme to add semi-colons everywhere
