### PR TITLE
Added extra error properties saving

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -17,6 +17,21 @@ module.exports.parseError = function parseError(err, kwargs, cb) {
         };
         kwargs['sentry.interfaces.Stacktrace'] = {frames: frames};
 
+        // Save additional error properties to `extra` under the error type (e.g. `extra.AttributeError`)
+        var extraErrorProps;
+        for (var key in err) {
+            if (err.hasOwnProperty(key)) {
+                if (key !== 'name' && key !== 'message' && key !== 'stack') {
+                    extraErrorProps = extraErrorProps || {};
+                    extraErrorProps[key] = err[key];
+                }
+            }
+        }
+        if (extraErrorProps) {
+            kwargs['extra'] = kwargs['extra'] || {};
+            kwargs['extra'][err.name] = extraErrorProps;
+        }
+
         for (var n = frames.length - 1; n >= 0; n--) {
             if (frames[n].in_app) {
                 kwargs['culprit'] = utils.getCulprit(frames[n]);

--- a/test/raven.parsers.js
+++ b/test/raven.parsers.js
@@ -1,3 +1,4 @@
+var assert = require('assert');
 var raven = require('../');
 var client = new raven.Client()
 raven.parsers = require('../lib/parsers');
@@ -129,6 +130,26 @@ describe('raven.parsers', function(){
           parsed['sentry.interfaces.Exception']['value'].should.equal('Cannot call method \'Derp\' of undefined');
           parsed.should.have.property('sentry.interfaces.Stacktrace');
           parsed['sentry.interfaces.Stacktrace'].should.have.property('frames');
+          done();
+        });
+      }
+    });
+
+    it('should parse an error with additional information', function(done){
+      try {
+        assert.strictEqual(1, 2);
+      } catch(e) {
+        raven.parsers.parseError(e, {}, function(parsed){
+          parsed.should.have.property('sentry.interfaces.Stacktrace');
+          parsed['sentry.interfaces.Stacktrace'].should.have.property('frames');
+          parsed.should.have.property('extra');
+          parsed['extra'].should.have.property('AssertionError');
+          parsed['extra']['AssertionError'].should.have.property('actual');
+          parsed['extra']['AssertionError']['actual'].should.equal(1);
+          parsed['extra']['AssertionError'].should.have.property('expected');
+          parsed['extra']['AssertionError']['expected'].should.equal(2);
+          parsed['extra']['AssertionError'].should.have.property('operator');
+          parsed['extra']['AssertionError']['operator'].should.equal('===');
           done();
         });
       }


### PR DESCRIPTION
As discussed in #71, it would be great to start logging extra error properties outside of the standard `type`/`message`. In this PR:
- Save non-standard error properties (e.g. `actual`, `expected` in `AssertionError`) to `extra.errorProperties`
