### PR TITLE
Add HTTPS detection via X-Forwarded-Proto

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -58,7 +58,7 @@ module.exports.parseRequest = function parseRequest(req, kwargs) {
 
     // create absolute url
     var host = req.headers.host || '<no host>';
-    var full_url = (req.socket.encrypted ? 'https' : 'http') + '://' + host + req.url;
+    var full_url = (req.socket.encrypted || 'https' === req.headers['x-forwarded-proto'] ? 'https' : 'http') + '://' + host + req.url;
 
     var http = {
         method: req.method,

--- a/test/raven.parsers.js
+++ b/test/raven.parsers.js
@@ -52,6 +52,27 @@ describe('raven.parsers', function(){
       parsed['sentry.interfaces.Http'].env.NODE_ENV.should.equal(process.env.NODE_ENV);
       parsed['sentry.interfaces.Http'].env.REMOTE_ADDR.should.equal('69.69.69.69');
     });
+
+    it('should detect https via `x-forwarded-proto`', function(){
+      var mockReq = {
+        method: 'GET',
+        url: '/some/path?key=value',
+        headers: {
+          host: 'mattrobenolt.com',
+          'x-forwarded-proto': 'https'
+        },
+        body: '',
+        cookies: {},
+        socket: {
+          encrypted: false
+        },
+        connection: {
+          remoteAddress: '69.69.69.69'
+        }
+      };
+      var parsed = raven.parsers.parseRequest(mockReq);
+      parsed['sentry.interfaces.Http'].url.should.equal('https://mattrobenolt.com/some/path?key=value');
+    });
   });
 
   describe('#parseError()', function(){


### PR DESCRIPTION
Similarly to `X-Forwarded-For`, `X-Forwarded-Proto` should also be taken into account when parsing the request object. One thing that stands out is that there is no whitelist support for filtering out spoofed values for `X-Forwarded-For`. Would you be open to integration with a more robust implementation such as [forwarded-for](https://www.npmjs.org/package/forwarded-for)?
