### PR TITLE
Storing all of env on parseRequest() is really noisy

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -2,6 +2,8 @@ var utils = require('./utils');
 var url = require('url');
 var cookie = require('cookie');
 
+var whiteList = module.exports.ENV_WHITE_LIST = ['REMOTE_ADDR', 'NODE_ENV'];
+
 module.exports.parseText = function parseText(message, kwargs) {
     kwargs = kwargs || {};
     kwargs['message'] = message;
@@ -67,11 +69,12 @@ module.exports.parseRequest = function parseRequest(req, kwargs) {
         cookies: req.cookies || cookie.parse(req.headers.cookies || ''),
         data: req.body || '<unavailable>',
         url: full_url,
-        env: {
-            REMOTE_ADDR: process.env.REMOTE_ADDR,
-            NODE_ENV: process.env.NODE_ENV
-        }
+        env: {}
     };
+
+    whiteList.forEach(function (key) {
+        http.env[key] = process.env[key];
+    });
 
     var ip = (req.headers['x-forwarded-for'] || '').split(',')[0] ||
              req.connection.remoteAddress;


### PR DESCRIPTION
It's probably not wise to send all of ENV since it can contain secure information.

We should probably only send what's actually needed.
