### PR TITLE
Replaced lsmod by package-list

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -47,8 +47,7 @@ _.get_ident = function getIdent(result) {
     return result.id;
 };
 
-_.process = function process(kwargs) {
-    kwargs['modules'] = utils.getModules();
+_.process = function process(kwargs, cb) {
     kwargs['server_name'] = kwargs['server_name'] || this.name;
     kwargs['extra'] = kwargs['extra'] || {};
     kwargs['extra']['node'] = process.version;
@@ -60,11 +59,16 @@ _.process = function process(kwargs) {
     kwargs['platform'] = 'node';
 
     var ident = {'id': kwargs['event_id']};
+    var self = this;
 
-    // this will happen asynchronously. We don't care about it's response.
-    this._enabled && this.send(kwargs, ident);
+    utils.getModules(function(err, pkgs) {
+        kwargs['modules'] = pkgs || {};
 
-    return ident;
+        // this will happen asynchronously. We don't care about it's response.
+        self._enabled && self.send(kwargs, ident);
+
+        cb && cb(ident);
+    });
 };
 
 _.send = function send(kwargs, ident) {
@@ -100,9 +104,7 @@ _.captureMessage = function captureMessage(message, kwargs, cb) {
     } else {
         kwargs = kwargs || {};
     }
-    var result = this.process(parsers.parseText(message, kwargs));
-    cb && cb(result);
-    return result;
+    this.process(parsers.parseText(message, kwargs), cb);
 };
 
 _.captureError =
@@ -124,8 +126,7 @@ _.captureException = function captureError(err, kwargs, cb) {
         kwargs = kwargs || {};
     }
     parsers.parseError(err, kwargs, function(kw) {
-        var result = self.process(kw);
-        cb && cb(result);
+        self.process(kw, cb);
     });
 };
 
@@ -136,9 +137,7 @@ _.captureQuery = function captureQuery(query, engine, kwargs, cb) {
     } else {
         kwargs = kwargs || {};
     }
-    var result = this.process(parsers.parseQuery(query, engine, kwargs));
-    cb && cb(result);
-    return result;
+    this.process(parsers.parseQuery(query, engine, kwargs), cb);
 };
 
 _.patchGlobal = function patchGlobal(cb) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var url = require('url');
 var transports = require('./transports');
 var path = require('path');
-var lsmod = require('lsmod');
+var packages = require('package-list');
 var stacktrace = require('stack-trace');
 
 var protocolMap = {
@@ -58,13 +58,8 @@ module.exports.getCulprit = function getCulprit(frame) {
     return '<unknown>';
 };
 
-var module_cache;
-module.exports.getModules = function getModules() {
-    if (module_cache) {
-        return module_cache;
-    }
-
-    return module_cache = lsmod();
+module.exports.getModules = function getModules(cb) {
+    return packages(cb);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "cookie": "0.1.0",
-    "lsmod": "~0.0.3",
     "node-uuid": "~1.4.1",
+    "package-list": "~0.0.3",
     "stack-trace": "0.0.7"
   },
   "devDependencies": {

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -339,7 +339,7 @@ describe('raven.Client', function(){
               var msg = JSON.parse(dec.toString());
               var modules = msg.modules;
 
-              modules.should.have.property('lsmod');
+              modules.should.have.property('package-list');
               modules.should.have.property('node-uuid');
               done();
             });


### PR DESCRIPTION
When using tools like `pm2`, the method used by `lsmod` is not capable of detecting the packages of the child process. This means that sentry will always receive the list of modules of pm2 and not of your project's own dependencies.

Here's an example for a project using `foo` and `package-list`as dependencies, plus `lsmod` installed but not added to the project's `package.json`:

```
Output from `lsmod`:
{ pm2: '0.7.7', 'coffee-script': '1.7.0' }
------
Output from `package-list`
{ foo: '1.0.0',
  'package-list': '0.0.1',
  lsmod: '0.0.3 (extraneous)' }
```

This is up for discussion as the async nature of `getModules` changes the return values of some functions.
