### PR TITLE
Move optional dependencies into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "mocha": "*",
     "mock-udp": "*",
     "nock": "~0.28.2",
-    "should": "~3.3.1"
-  },
-  "optionalDependencies": {
+    "should": "~3.3.1",
     "connect": "*",
     "express": "*",
     "koa": "*"


### PR DESCRIPTION
These shouldn't be dependencies, since raven-node doesn't directly use them.  It results in my package attempting to install koa when it just uses express.
