### PR TITLE
Automatically parse request in captureMessage/captureError (#82)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -105,7 +105,11 @@ _.captureMessage = function captureMessage(message, kwargs, cb) {
     } else {
         kwargs = kwargs || {};
     }
-    var result = this.process(parsers.parseText(message, kwargs));
+    kwargs = parsers.parseText(message, kwargs);
+    if (kwargs.request) {
+        kwargs = parsers.parseRequest(kwargs.request, kwargs);
+    }
+    var result = this.process(kwargs);
     cb && cb(result);
     return result;
 };
@@ -126,6 +130,9 @@ _.captureException = function captureError(err, kwargs, cb) {
     } else {
         kwargs = kwargs || {};
     }
+    if (kwargs.request) {
+        kwargs = parsers.parseRequest(kwargs.request);
+    }
     parsers.parseError(err, kwargs, function(kw) {
         var result = self.process(kw);
         cb && cb(result);
@@ -139,7 +146,11 @@ _.captureQuery = function captureQuery(query, engine, kwargs, cb) {
     } else {
         kwargs = kwargs || {};
     }
-    var result = this.process(parsers.parseQuery(query, engine, kwargs));
+    kwargs = parsers.parseQuery(query, engine, kwargs);
+    if (kwargs.request) {
+        kwargs = parsers.parseRequest(kwargs.request, context);
+    }
+    var result = this.process(kwargs);
     cb && cb(result);
     return result;
 };

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -196,8 +196,9 @@ describe('raven.Client', function(){
                 client.send = old;
 
                 kwargs['message'].should.equal("Error: wtf?");
-                kwargs.should.have.property('sentry.interfaces.Stacktrace');
-                var stack = kwargs['sentry.interfaces.Stacktrace'];
+                kwargs.should.have.property('exception');
+                kwargs['exception'][0].should.have.property('stacktrace');
+                var stack = kwargs['exception'][0]['stacktrace'];
                 stack.frames[stack.frames.length-1]['function'].should.equal('Client.captureError');
                 done();
             };

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -17,6 +17,23 @@ function restoreConsoleWarn() {
     console.warn = _oldConsoleWarn;
 }
 
+var mockRequest = {
+    method: 'GET',
+    url: '/some/path?key=value',
+    headers: {
+        host: 'mattrobenolt.com'
+    },
+    body: '',
+    cookies: {},
+    socket: {
+        encrypted: true
+    },
+    connection: {
+        remoteAddress: '69.69.69.69'
+    }
+};
+
+
 describe('raven.version', function(){
     it('should be valid', function(){
         raven.version.should.match(/^\d+\.\d+\.\d+(-\w+)?$/);
@@ -174,6 +191,36 @@ describe('raven.Client', function(){
 
             client.captureMessage('Hey!');
         });
+
+        it('should find a request object in kwargs and parse it', function(done){
+            var old = client.send;
+
+            client.send = function mockSend(kwargs) {
+                client.send = old;
+
+                kwargs['message'].should.equal("something happened");
+                kwargs.should.have.property('request');
+                kwargs['request'].should.have.property['url']
+                kwargs['request']['url'].should.equal("https://mattrobenolt.com/some/path?key=value")
+                done();
+            };
+            client.captureMessage('something happened', {request: mockRequest});
+        });
+
+        it('should find a description object in kwargs and pass it along', function(done){
+            var old = client.send;
+
+            client.send = function mockSend(kwargs) {
+                client.send = old;
+
+                kwargs['message'].should.equal("something happened");
+                kwargs.should.have.property('description');
+                kwargs['description'].should.equal("Some context");
+                done();
+            };
+            client.captureMessage('something happened', {description: "Some context"});
+        });
+
     });
 
     describe('#captureError()', function(){
@@ -203,6 +250,35 @@ describe('raven.Client', function(){
                 done();
             };
             client.captureError('wtf?');
+        });
+
+        it('should find a request object in kwargs and parse it', function(done){
+            var old = client.send;
+
+            client.send = function mockSend(kwargs) {
+                client.send = old;
+
+                kwargs['message'].should.equal("Error: wtf?");
+                kwargs.should.have.property('request');
+                kwargs['request'].should.have.property['url']
+                kwargs['request']['url'].should.equal("https://mattrobenolt.com/some/path?key=value")
+                done();
+            };
+            client.captureError(new Error('wtf?'), {request: mockRequest});
+        });
+
+        it('should find a description object in kwargs and pass it along', function(done){
+            var old = client.send;
+
+            client.send = function mockSend(kwargs) {
+                client.send = old;
+
+                kwargs['message'].should.equal("Error: wtf?");
+                kwargs.should.have.property('description');
+                kwargs['description'].should.equal("Some context");
+                done();
+            };
+            client.captureError(new Error('wtf?'), {description: "Some context"});
         });
 
         it('should send an Error to Sentry server on another port', function(done){


### PR DESCRIPTION
As discussed in #82, automatically find a request object passed in kwargs to captureMessage()/captureError() and parse it.

``` javascript
client.captureMessage("hi", {request:req});
client.captureError(err, {request:req});
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/92)

<!-- Reviewable:end -->
