### PR TITLE
Client takes additional request-context callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,19 +186,6 @@ app.listen(3000);
 
 __Note__: `raven.middleware.express` or `raven.middleware.connect` *must* be added to the middleware stack *before* any other error handling middlewares or there's a chance that the error will never get to Sentry.
 
-Both middlewares take an optional `parseRequest` function that will be called with the request and data being sent. It should return additional data and can be used to track user impact:
-
-```javascript
-app.use(raven.middleware.express('{{ SENTRY_DSN }}', function(req, data) {
-  data = data || {};
-
-  data.user = data.user || {};
-  data.user.email = req.person.email;
-
-  return data;
-}));
-```
-
 ## Coffeescript
 In order to use raven-node with coffee-script or another library which overwrites
 Error.prepareStackTrace you might run into the exception "Traceback does not support Error.prepareStackTrace being defined already."
@@ -224,6 +211,19 @@ Pass the `dataCallback` configuration value:
 client = new raven.Client('{{ SENTRY_DSN }}', {
   dataCallback: function(data) {
     delete data.request.env;
+    return data;
+  }
+});
+```
+
+Use `requestCallback` if you want to modify the data based associated with a
+request. It should return additional data and can be used to track user impact:
+
+```javascript
+client = new raven.Client('{{ SENTRY_DSN }}', {
+  requestCallback: function(data, req) {
+    data.user = data.user || {};
+    data.user.email = req.person.email;
     return data;
   }
 });

--- a/README.md
+++ b/README.md
@@ -191,8 +191,9 @@ Both middlewares take an optional `parseRequest` function that will be called wi
 ```javascript
 app.use(raven.middleware.express('{{ SENTRY_DSN }}', function(req, data) {
   data = data || {};
+
   data.user = data.user || {};
-  data.user.email = req.session.email;
+  data.user.email = req.person.email;
 
   return data;
 }));

--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ app.listen(3000);
 
 __Note__: `raven.middleware.express` or `raven.middleware.connect` *must* be added to the middleware stack *before* any other error handling middlewares or there's a chance that the error will never get to Sentry.
 
+Both middlewares take an optional `parseRequest` function that will be called with the request and data being sent. It should return additional data and can be used to track user impact:
+
+```javascript
+app.use(raven.middleware.express('{{ SENTRY_DSN }}', function(req, data) {
+  data = data || {};
+  data.user = data.user || {};
+  data.user.email = req.session.email;
+
+  return data;
+}));
+```
+
 ## Coffeescript
 In order to use raven-node with coffee-script or another library which overwrites
 Error.prepareStackTrace you might run into the exception "Traceback does not support Error.prepareStackTrace being defined already."

--- a/lib/client.js
+++ b/lib/client.js
@@ -30,6 +30,7 @@ var Client = function Client(dsn, options) {
 
     this.loggerName = options.logger || '';
     this.dataCallback = options.dataCallback;
+    this.requestCallback = options.requestCallback;
 
     // enabled if a dsn is set
     this._enabled = !!this.dsn;

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -1,7 +1,7 @@
 var raven = require('../client');
 var parsers = require('../parsers');
 
-module.exports = function connectMiddleware(client) {
+module.exports = function connectMiddleware(client, parseRequest) {
     client = (client instanceof raven.Client) ? client : new raven.Client(client);
     return function(err, req, res, next) {
         var status = err.status || err.statusCode || err.status_code || 500;
@@ -10,6 +10,8 @@ module.exports = function connectMiddleware(client) {
         if (status < 500) return next(err);
 
         var kwargs = parsers.parseRequest(req);
+        if (parseRequest)
+            kwargs = parseRequest(req, kwargs);
         client.captureError(err, kwargs, function(result) {
             res.sentry = client.getIdent(result);
             next(err, req, res);

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -1,7 +1,7 @@
 var raven = require('../client');
 var parsers = require('../parsers');
 
-module.exports = function connectMiddleware(client, parseRequest) {
+module.exports = function connectMiddleware(client) {
     client = (client instanceof raven.Client) ? client : new raven.Client(client);
     return function(err, req, res, next) {
         var status = err.status || err.statusCode || err.status_code || 500;
@@ -10,8 +10,9 @@ module.exports = function connectMiddleware(client, parseRequest) {
         if (status < 500) return next(err);
 
         var kwargs = parsers.parseRequest(req);
-        if (parseRequest)
-            kwargs = parseRequest(req, kwargs);
+        if (client.requestCallback) {
+            kwargs = client.requestCallback(kwargs, req);
+        }
         client.captureError(err, kwargs, function(result) {
             res.sentry = client.getIdent(result);
             next(err, req, res);


### PR DESCRIPTION
I needed to augment my exception data with user-based tags. I noticed sentry would automatically tag events with the number of affected distinct users if the client sends along user.email. This change provides a callback facility to augment the event with more data, based on the request.
