### PR TITLE
Add an optional middleware callback to alter data before sending to Sentry

### DIFF
--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -1,7 +1,7 @@
 var raven = require('../client');
 var parsers = require('../parsers');
 
-module.exports = function connectMiddleware(client) {
+module.exports = function connectMiddleware(client, dataCb) {
     client = (client instanceof raven.Client) ? client : new raven.Client(client);
     return function(err, req, res, next) {
         var status = err.status || err.statusCode || err.status_code || 500;
@@ -10,6 +10,9 @@ module.exports = function connectMiddleware(client) {
         if (status < 500) return next(err);
 
         var kwargs = parsers.parseRequest(req);
+
+        if (typeof dataCb === 'function') dataCb(kwargs, err, req);
+
         client.captureError(err, kwargs, function(result) {
             res.sentry = client.getIdent(result);
             next(err, req, res);


### PR DESCRIPTION
I'm using raven-node in a project with the Express/Connect middleware, and I needed a way to alter the data that's being sent to Sentry in order to add information about the logged in user. This info changes depending on the request, so I needed access to the request and error objects in order to determine what to send along.

I thought this might be a generally useful feature for people who use the middleware and want to add request or error-specific info to their Sentry reporting, so I thought I'd submit a pull request.

I didn't see any tests for the middleware, but if you think this is a good idea, let me know if there's anything else I should add to the pull.