### PR TITLE
Disabled clients should trigger callbacks

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -67,7 +67,12 @@ _.process = function process(kwargs) {
     }
 
     // this will happen asynchronously. We don't care about it's response.
-    this._enabled && this.send(kwargs, ident);
+    if (this._enabled) {
+        this.send(kwargs, ident);
+    } else {
+        // noop, but claim that we logged it
+        this.emit('logged', ident);
+    }
 
     return ident;
 };

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -324,6 +324,29 @@ describe('raven.Client', function(){
 
             process.emit('uncaughtException', new Error('derp'));
         });
+
+        it('should trigger a callback when disabled', function(done){
+            // remove existing uncaughtException handlers
+            var uncaughtBefore = process._events.uncaughtException;
+            process.removeAllListeners('uncaughtException');
+
+            // patchGlobal with a client that will be disabled (undefined
+            // because typeof null === 'object' and typeof undefined ===
+            // 'undefined')
+            new raven.Client(undefined).patchGlobal(function(success, err){
+                success.should.eql(true);
+                err.should.be.instanceOf(Error);
+                err.message.should.equal('derp');
+
+                // restore things to how they were
+                process._events.uncaughtException = uncaughtBefore;
+
+                done();
+            });
+
+
+            process.emit('uncaughtException', new Error('derp'));
+        });
     });
 
     describe('#process()', function(){


### PR DESCRIPTION
Without this, boilerplate like...

``` javascript
raven.patchGlobal(function(success, err) {
  console.error(err.stack);
  process.exit(1);
});
```

...won't fire when the underlying client is disabled (i.e. no `SENTRY_DSN`).  However, the `uncaughtException` handler will still be registered, effectively swallowing errors.

This patch causes the client to pretend to have logged the request, allowing `patchGlobal` to trigger custom callbacks as would happen if it were enabled.
