### PR TITLE
Update Express example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,11 @@ connect(
 #### Express
 ```javascript
 var app = require('express')();
-app.use(app.router);
-app.use(raven.middleware.express('{{ SENTRY_DSN }}'));
-app.use(onError); // optional error handler if you want to display the error id to a user
 app.get('/', function mainHandler(req, res) {
   throw new Error('Broke!');
 });
+app.use(raven.middleware.express('{{ SENTRY_DSN }}'));
+app.use(onError); // optional error handler if you want to display the error id to a user
 app.listen(3000);
 ```
 


### PR DESCRIPTION
As stated in https://github.com/strongloop/express/wiki/Migrating-from-3.x-to-4.x#approuter, `app.router` has been removed in Express 4.
Plus, `app.use(raven.middleware.express('{{ SENTRY_DSN }}'));` should be used after all routes have been defined (as mentioned in #24).
