### PR TITLE
update to use /api/{projectId}/store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.6"
   - "0.8"
   - "0.10"
   - "0.11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ node_js:
   - "0.10"
   - "0.11"
 before_install:
-  - "npm install --upgrade npm -g"
+  - "npm install npm@latest -g"

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -14,7 +14,7 @@ util.inherits(HTTPTransport, Transport);
 HTTPTransport.prototype.send = function(client, message, headers, ident) {
     var options = {
         hostname: client.dsn.host,
-        path: client.dsn.path + 'api/store/',
+        path: client.dsn.path + 'api/' + client.dsn.project_id + '/store/',
         headers: headers,
         method: 'POST',
         port: client.dsn.port || this.defaultPort

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "raven": "./bin/raven"
   },
   "scripts": {
-    "test": "NODE_ENV=test mocha --reporter spec"
+    "pretest": "npm install",
+    "test": "NODE_ENV=test mocha --reporter dot && NODE_ENV=test coffee ./test/run.coffee"
   },
   "engines": {
     "node": ">= 0.6.0"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "raven": "./bin/raven"
   },
   "scripts": {
-    "pretest": "npm install",
-    "test": "NODE_ENV=test mocha --reporter dot && NODE_ENV=test coffee ./test/run.coffee"
+    "test": "NODE_ENV=test mocha --reporter spec"
   },
   "engines": {
     "node": ">= 0.6.0"

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -328,7 +328,7 @@ describe('raven.Client', function(){
         it('should respect dataCallback', function(){
             var scope = nock('https://app.getsentry.com')
                 .filteringRequestBody(/.*/, '*')
-                .post('/api/store/', '*')
+                .post('/api/269/store/', '*')
                 .reply(200, function(uri, body) {
                     zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
                       if (err) return done(err);
@@ -416,7 +416,7 @@ describe('raven.Client', function(){
     it('should capture extra data', function(done) {
         var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
-        .post('/api/store/', '*')
+        .post('/api/269/store/', '*')
         .reply(200, function(uri, body) {
             zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
               if (err) return done(err);
@@ -440,7 +440,7 @@ describe('raven.Client', function(){
     it('should capture tags', function(done) {
         var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
-        .post('/api/store/', '*')
+        .post('/api/269/store/', '*')
         .reply(200, function(uri, body) {
             zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
               if (err) return done(err);

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -124,7 +124,7 @@ describe('raven.Client', function(){
         it('should send a plain text message to Sentry server', function(done){
             var scope = nock('https://app.getsentry.com')
                 .filteringRequestBody(/.*/, '*')
-                .post('/api/store/', '*')
+                .post('/api/269/store/', '*')
                 .reply(200, 'OK');
 
             client.on('logged', function(){
@@ -137,7 +137,7 @@ describe('raven.Client', function(){
         it('should emit error when request returns non 200', function(done){
             var scope = nock('https://app.getsentry.com')
                 .filteringRequestBody(/.*/, '*')
-                .post('/api/store/', '*')
+                .post('/api/269/store/', '*')
                 .reply(500, 'Oops!');
 
             client.on('error', function(){
@@ -150,7 +150,7 @@ describe('raven.Client', function(){
         it('shouldn\'t shit it\'s pants when error is emitted without a listener', function(){
             var scope = nock('https://app.getsentry.com')
                 .filteringRequestBody(/.*/, '*')
-                .post('/api/store/', '*')
+                .post('/api/269/store/', '*')
                 .reply(500, 'Oops!');
 
             client.captureMessage('Hey!');
@@ -159,7 +159,7 @@ describe('raven.Client', function(){
         it('should attach an Error object when emitting error', function(done){
             var scope = nock('https://app.getsentry.com')
                 .filteringRequestBody(/.*/, '*')
-                .post('/api/store/', '*')
+                .post('/api/269/store/', '*')
                 .reply(500, 'Oops!', {'x-sentry-error': 'Oops!'});
 
             client.on('error', function(e){
@@ -178,7 +178,7 @@ describe('raven.Client', function(){
         it('should send an Error to Sentry server', function(done){
             var scope = nock('https://app.getsentry.com')
                 .filteringRequestBody(/.*/, '*')
-                .post('/api/store/', '*')
+                .post('/api/269/store/', '*')
                 .reply(200, 'OK');
 
             client.on('logged', function(){
@@ -205,7 +205,7 @@ describe('raven.Client', function(){
         it('should send an Error to Sentry server on another port', function(done){
             var scope = nock('https://app.getsentry.com:8443')
                 .filteringRequestBody(/.*/, '*')
-                .post('/api/store/', '*')
+                .post('/api/269/store/', '*')
                 .reply(200, 'OK');
 
             var dsn = 'https://public:private@app.getsentry.com:8443/269';
@@ -233,7 +233,7 @@ describe('raven.Client', function(){
             // See: https://github.com/mattrobenolt/raven-node/pull/46
             var scope = nock('https://app.getsentry.com')
                 .filteringRequestBody(/.*/, '*')
-                .post('/api/store/', '*')
+                .post('/api/269/store/', '*')
                 .reply(200, 'OK');
 
             client.on('logged', function(){
@@ -258,7 +258,7 @@ describe('raven.Client', function(){
         it('should send an uncaughtException to Sentry server', function(done){
             var scope = nock('https://app.getsentry.com')
                 .filteringRequestBody(/.*/, '*')
-                .post('/api/store/', '*')
+                .post('/api/269/store/', '*')
                 .reply(200, 'OK');
 
             // remove existing uncaughtException handlers
@@ -279,7 +279,7 @@ describe('raven.Client', function(){
         it('should trigger a callback after an uncaughtException', function(done){
             var scope = nock('https://app.getsentry.com')
                 .filteringRequestBody(/.*/, '*')
-                .post('/api/store/', '*')
+                .post('/api/269/store/', '*')
                 .reply(200, 'OK');
 
             // remove existing uncaughtException handlers
@@ -380,7 +380,7 @@ describe('raven.Client', function(){
 
         var scope = nock('https://app.getsentry.com')
             .filteringRequestBody(/.*/, '*')
-            .post('/some/path/api/store/', '*')
+            .post('/some/path/api/269/store/', '*')
             .reply(200, 'OK');
 
         client.on('logged', function(){
@@ -393,7 +393,7 @@ describe('raven.Client', function(){
     it('should capture module information', function(done) {
         var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
-        .post('/api/store/', '*')
+        .post('/api/269/store/', '*')
         .reply(200, function(uri, body) {
             zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
               if (err) return done(err);


### PR DESCRIPTION
The default recommended rate limiting on the sentry
    documentation rate limits by `projectId`.

It's a better default to talk to a sentry server using the
    `/api/{projectId}/store` API.

This way multiple services talking to the same sentry
    server will not all get rate limited under the same
    projectId (which is presumably the empty string).