### PR TITLE
Added support for RELEASE tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Optionally set the name for the client to use. [What is name?](http://raven.read
 ### SENTRY_SITE
 Optionally set the site for the client to use. [What is site?](http://raven.readthedocs.org/en/latest/config/index.html#site)
 
+### RELEASE
+Optionally set the application release version for the client to use, this is usually a Git SHA hash. Raven will also check to see whether
+the VERSION environment variable is set if it cannot find RELEASE.
+
 ## Catching global errors
 For those times when you don't catch all errors in your application. ;)
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -31,7 +31,7 @@ var Client = function Client(dsn, options) {
     this.loggerName = options.logger || '';
     this.dataCallback = options.dataCallback;
 
-    this.release = options.release || process.env.RELEASE || process.env.VERSION || '';
+    this.release = options.release || process.env.SENTRY_RELEASE || '';
 
     // enabled if a dsn is set
     this._enabled = !!this.dsn;

--- a/lib/client.js
+++ b/lib/client.js
@@ -31,6 +31,8 @@ var Client = function Client(dsn, options) {
     this.loggerName = options.logger || '';
     this.dataCallback = options.dataCallback;
 
+    this.release = options.release || process.env.RELEASE || process.env.VERSION || '';
+
     // enabled if a dsn is set
     this._enabled = !!this.dsn;
 
@@ -60,6 +62,11 @@ _.process = function process(kwargs) {
     kwargs['timestamp'] = new Date().toISOString().split('.')[0];
     kwargs['project'] = this.dsn.project_id;
     kwargs['platform'] = 'node';
+    
+    // Only include release information if it is set
+    if (this.release) {
+        kwargs['release'] = this.release;
+    }
 
     var ident = {'id': kwargs['event_id']};
 

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -111,6 +111,25 @@ describe('raven.Client', function(){
         restoreConsoleWarn();
     });
 
+    it('should pull RELEASE from options if present', function(){
+        var client = new raven.Client(dsn, { release: 'version1' });
+        client.release.should.eql('version1'); 
+    });
+
+    it('should pull RELEASE from environment', function(){
+        process.env.RELEASE='version1';
+        var client = new raven.Client(dsn);
+        client.release.should.eql('version1');
+        delete process.env.RELEASE;
+    });
+
+    it('should pull RELEASE from environment (VERSION)', function(){
+        process.env.VERSION='version1';
+        var client = new raven.Client(dsn);
+        client.release.should.eql('version1');
+        delete process.env.VERSION;
+    });
+
     describe('#getIdent()', function(){
         it('should match', function(){
             var result = {


### PR DESCRIPTION
Included in Protocol v6 as defined in [the protocol docs](http://sentry.readthedocs.org/en/7.0.0/developer/client/index.html). This implementation pulls its information from the constructor's `options` or `process.env.RELEASE` or `process.env.VERSION` (in that order).
This makes the client fully compatible with Sentry 7+

I've included some basic tests as well as an addition to the README which provides a quick introduction regarding the use of the feature.

**TODO**
- Bump `package.json` version
- Release into the wild
