### PR TITLE
Use custom certificate for HTTPS

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -31,6 +31,11 @@ var Client = function Client(dsn, options) {
     this.loggerName = options.logger || '';
     this.dataCallback = options.dataCallback;
 
+    if(this.dsn.protocol === 'https'){
+        // In case we want to provide our own SSL certificates / keys
+        this.ca = options.ca || null;
+    }
+
     // enabled if a dsn is set
     this._enabled = !!this.dsn;
 

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -17,7 +17,8 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
         path: client.dsn.path + 'api/store/',
         headers: headers,
         method: 'POST',
-        port: client.dsn.port || this.defaultPort
+        port: client.dsn.port || this.defaultPort,
+        ca: client.ca
     }, req = this.transport.request(options, function(res){
         res.setEncoding('utf8');
         if(res.statusCode >= 200 && res.statusCode < 300) {


### PR DESCRIPTION
References #108 

``ca`` parameter will be given to HTTPS requests. If http, it will don't change anything.

I tested it on my setup but I wasn't able to write tests. If you have an idea of to implement shuch tests, tell me and I'll write them.