### PR TITLE
Fix documentation about logging level and stackFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ You can specify a level in the second optional parameter. Default level is `erro
 ```javascript
 var raven = require('raven');
 
-var client = new raven.Client('{{ SENTRY_DSN }}', {level: 'warning'});
+var client = new raven.Client('{{ SENTRY_DSN }}');
 
-client.captureMessage("Another message")
+client.captureMessage("Another message", {level: 'warning'});
 ```
 
 **Adding extra info an event**
@@ -58,7 +58,7 @@ var raven = require('raven');
 
 var client = new raven.Client('{{ SENTRY_DSN }}');
 
-client.captureMessage("Another message", {extra: {'key': 'value'}})
+client.captureMessage("Another message", {extra: {'key': 'value'}});
 ```
 
 **Adding tags to an event**
@@ -67,7 +67,7 @@ var raven = require('raven');
 
 var client = new raven.Client('{{ SENTRY_DSN }}');
 
-client.captureMessage("Another message", {tags: {'key': 'value'}})
+client.captureMessage("Another message", {tags: {'key': 'value'}});
 ```
 
 ## Logging an error

--- a/README.md
+++ b/README.md
@@ -186,24 +186,6 @@ app.listen(3000);
 
 __Note__: `raven.middleware.express` or `raven.middleware.connect` *must* be added to the middleware stack *before* any other error handling middlewares or there's a chance that the error will never get to Sentry.
 
-## Coffeescript
-In order to use raven-node with coffee-script or another library which overwrites
-Error.prepareStackTrace you might run into the exception "Traceback does not support Error.prepareStackTrace being defined already."
-
-In order to not have raven-node (and the underlying raw-stacktrace library) require
-Traceback you can pass your own stackFunction in the options. For example:
-
-```coffeescript
-client = new raven.Client('{{ SENTRY_DSN }}', { stackFunction: {{ Your stack function }}});
-```
-
-So for example:
-```coffeescript
-client = new raven.Client('{{ SENTRY_DSN }}', {
-  stackFunction: Error.prepareStackTrace
-});
-```
-
 ## Pre-processing data
 Pass the `dataCallback` configuration value:
 


### PR DESCRIPTION
AFAIK setting the logging level on the client constructor doesn't do anything XD
Fixed the readme to put the level parameter on the correct line.

Also, looks like `stackFunction` was removed in 2b6586430dfc9ff35070ad9197be07a9855840ea, so I've removed it from the readme.