### PR TITLE
Update utils.js

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -134,8 +134,9 @@ function parseStack(err, cb) {
             lineno: line.getLineNumber(),
             'function': getFunction(line),
         }, isInternal = line.isNative() ||
-                        (frame.filename[0] !== '/' &&
-                         frame.filename[0] !== '.');
+                        (frame.filename[0] !== path.sep &&
+                         frame.filename[0] !== '.'
+                         frame.filename.indexOf(':\\') != 1);
 
         // in_app is all that's not an internal Node function or a module within node_modules
         frame.in_app = !isInternal && !~frame.filename.indexOf('node_modules/');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -135,7 +135,7 @@ function parseStack(err, cb) {
             'function': getFunction(line),
         }, isInternal = line.isNative() ||
                         (frame.filename[0] !== path.sep &&
-                         frame.filename[0] !== '.'
+                         frame.filename[0] !== '.' &&
                          frame.filename.indexOf(':\\') != 1);
 
         // in_app is all that's not an internal Node function or a module within node_modules

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -136,7 +136,7 @@ function parseStack(err, cb) {
         }, isInternal = line.isNative() ||
                         (frame.filename[0] !== path.sep &&
                          frame.filename[0] !== '.' &&
-                         frame.filename.indexOf(':\\') != 1);
+                         frame.filename.indexOf(':\\') !== 1);
 
         // in_app is all that's not an internal Node function or a module within node_modules
         frame.in_app = !isInternal && !~frame.filename.indexOf('node_modules/');

--- a/test/raven.utils.js
+++ b/test/raven.utils.js
@@ -108,6 +108,23 @@ describe('raven.utils', function() {
       parseStack([], callback);
       parseStack([{lol: 1}], callback);
     });
+
+    it('should extract context from last stack line', function(done){
+      var parseStack = raven.utils.parseStack;
+      var callback = function(frames) {
+        var frame = frames.pop();
+        frame.pre_context.should.be.an.instanceOf(Array);
+        frame.context_line.should.be.type('string');
+        frame.context_line.should.endWith('undeclared_function();');
+        frame.post_context.should.be.an.instanceOf(Array);
+        done();
+      };
+      try {
+        undeclared_function();
+      } catch(e) {
+        parseStack(e, callback);
+      }
+    });
   });
 
   describe('#getCulprit()', function(){


### PR DESCRIPTION
Please consider the proposed change.The source code of the non-native stacktrace lines was never fetched on Windows machines. That's because isInternal was always resolving to true no matter what:

``` js

isInternal = line.isNative() || (frame.filename[0] !== '/' && frame.filename[0] !== '.'); 

```

I added 2 small modifications:
1) the hardcoded separator ('/') has been replaced with path.sep (please refer to: https://nodejs.org/api/path.html#path_path_sep). That way the check is valid for all platforms: '/' for linux and '\' for windows
2) an extra check has been added: frame.filename.indexOf(':\') != 1
That way absolute paths on windows are considered non-native.
