### PR TITLE
Add passing extra options to HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,18 @@ You can specify a level in the second optional parameter. Default level is `erro
 
 ```javascript
 var raven = require('raven');
-
 var client = new raven.Client('{{ SENTRY_DSN }}', {level: 'warning'});
 
-client.captureMessage("Another message")
+client.captureMessage('Another message')
 ```
 
-**Adding extra info an event**
+**Passing extra HTTP transport options**
+```javascript
+var raven = require('raven');
+var client = new raven.Client('{{ SENTRY_DSN }}', {transport: new raven.transports.HTTPSTransport({rejectUnauthorized: false})});
+```
+
+**Adding extra info to an event**
 ```javascript
 var raven = require('raven');
 

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -6,9 +6,10 @@ function Transport() {
 util.inherits(Transport, events.EventEmitter);
 
 var http = require('http');
-function HTTPTransport() {
+function HTTPTransport(options) {
     this.defaultPort = 80;
     this.transport = http;
+    this.options = options || {};
 }
 util.inherits(HTTPTransport, Transport);
 HTTPTransport.prototype.send = function(client, message, headers, ident) {
@@ -19,7 +20,13 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
         method: 'POST',
         port: client.dsn.port || this.defaultPort,
         ca: client.ca
-    }, req = this.transport.request(options, function(res){
+    };
+    for (var key in this.options) {
+        if (this.options.hasOwnProperty(key)) {
+            options[key] = this.options[key];
+        }
+    }
+    var req = this.transport.request(options, function(res){
         res.setEncoding('utf8');
         if(res.statusCode >= 200 && res.statusCode < 300) {
             client.emit('logged', ident);
@@ -46,9 +53,10 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
 };
 
 var https = require('https');
-function HTTPSTransport() {
+function HTTPSTransport(options) {
     this.defaultPort = 443;
     this.transport = https;
+    this.options = options || {};
 }
 util.inherits(HTTPSTransport, HTTPTransport);
 
@@ -74,3 +82,5 @@ module.exports.http = new HTTPTransport();
 module.exports.https = new HTTPSTransport();
 module.exports.udp = new UDPTransport();
 module.exports.Transport = Transport;
+module.exports.HTTPTransport = HTTPTransport;
+module.exports.HTTPSTransport = HTTPSTransport;


### PR DESCRIPTION
**Passing extra HTTP transport options**
```javascript
var raven = require('raven');
var client = new raven.Client('{{ SENTRY_DSN }}', {transportOptions: {rejectUnauthorized: false}});
 ```

fix #115