### PR TITLE
Fix for callback flow to fix #86

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -80,8 +80,8 @@ _.process = function process(kwargs, callback) {
 
     // this will happen asynchronously. We don't care about it's response.
     this._enabled ? this.send(kwargs, ident, function (err) {
-        callback && callback(err, ident);
-    }) : (callback && callback(null, ident));
+        callback && callback(ident);
+    }) : (callback && callback(ident));
 
     return ident;
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -119,9 +119,8 @@ _.captureMessage = function captureMessage(message, kwargs, cb) {
     } else {
         kwargs = kwargs || {};
     }
-    var result = this.process(parsers.parseText(message, kwargs));
-    cb && cb(result);
-    return result;
+
+    return this.process(parsers.parseText(message, kwargs), cb);
 };
 
 _.captureError =
@@ -141,8 +140,7 @@ _.captureException = function captureError(err, kwargs, cb) {
         kwargs = kwargs || {};
     }
     parsers.parseError(err, kwargs, function(kw) {
-        var result = self.process(kw);
-        cb && cb(result);
+        self.process(kw, cb);
     });
 };
 
@@ -153,9 +151,8 @@ _.captureQuery = function captureQuery(query, engine, kwargs, cb) {
     } else {
         kwargs = kwargs || {};
     }
-    var result = this.process(parsers.parseQuery(query, engine, kwargs));
-    cb && cb(result);
-    return result;
+
+    return this.process(parsers.parseQuery(query, engine, kwargs), cb);
 };
 
 _.patchGlobal = function patchGlobal(cb) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -53,7 +53,7 @@ _.get_ident = function getIdent(result) {
     return result.id;
 };
 
-_.process = function process(kwargs) {
+_.process = function process(kwargs, callback) {
     kwargs['modules'] = utils.getModules();
     kwargs['server_name'] = kwargs['server_name'] || this.name;
     kwargs['extra'] = kwargs['extra'] || {};
@@ -79,12 +79,14 @@ _.process = function process(kwargs) {
     }
 
     // this will happen asynchronously. We don't care about it's response.
-    this._enabled && this.send(kwargs, ident);
+    this._enabled ? this.send(kwargs, ident, function (err) {
+        callback && callback(err, ident);
+    }) : (callback && callback(null, ident));
 
     return ident;
 };
 
-_.send = function send(kwargs, ident) {
+_.send = function send(kwargs, ident, callback) {
     var self = this;
 
     // stringify, but don't choke on circular references, see: http://stackoverflow.com/questions/11616630/json-stringify-avoid-typeerror-converting-circular-structure-to-json
@@ -106,7 +108,7 @@ _.send = function send(kwargs, ident) {
                 'Content-Length': message.length
             };
 
-        self.transport.send(self, message, headers, ident);
+        self.transport.send(self, message, headers, ident, callback);
     });
 };
 

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -66,16 +66,18 @@ function UDPTransport() {
     this.defaultPort = 12345;
 }
 util.inherits(UDPTransport, Transport);
-UDPTransport.prototype.send = function(client, message, headers, ident) {
+UDPTransport.prototype.send = function(client, message, headers, ident, callback) {
     message = new Buffer(headers['X-Sentry-Auth'] + '\n\n'+ message);
 
     var udp = dgram.createSocket('udp4');
     udp.send(message, 0, message.length, client.dsn.port || this.defaultPort, client.dsn.host, function(e, bytes) {
         if(e){
+            callback && callback(e);
             return client.emit('error', e);
         }
         client.emit('logged', ident);
         udp.close();
+        callback && callback();
     });
 };
 

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -12,7 +12,7 @@ function HTTPTransport(options) {
     this.options = options || {};
 }
 util.inherits(HTTPTransport, Transport);
-HTTPTransport.prototype.send = function(client, message, headers, ident) {
+HTTPTransport.prototype.send = function(client, message, headers, ident, callback) {
     var options = {
         hostname: client.dsn.host,
         path: client.dsn.path + 'api/' + client.dsn.project_id + '/store/',
@@ -44,9 +44,10 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
         // force the socket to drain
         var noop = function(){};
         res.on('data', noop);
-        res.on('end', noop);
+        res.on('end', callback || noop);
     });
     req.on('error', function(e){
+        callback && callback(e);
         client.emit('error', e);
     });
     req.end(message);


### PR DESCRIPTION
This PR fixes issue with the callback flow of `client.capture*` functions where it now gets called *after* the transporter has finished sending the logs to server.

Case in point:

The following code *does not* work since process.exit() kills all ongoing transports.

```javascript
client.captureError(err, {}, function () {
    process.exit(1);
});
```

This PR fixes this.