### PR TITLE
Prevent off-heap memory explosion when request is stacking.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -37,6 +37,7 @@ var Client = function Client(dsn, options) {
         this.ca = options.ca || null;
     }
 
+	this.maxReqQueueCount = options.maxReqQueueCount || 200;
     // enabled if a dsn is set
     this._enabled = !!this.dsn;
 

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -26,6 +26,16 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
             options[key] = this.options[key];
         }
     }
+	// in case sentry server is down
+	var _agent = options.agent || this.transport.globalAgent;
+	if (!_agent) {
+		_name = client.dsn.host + ":" + client.dsn.port;
+		_requests = _agent.requests[_name];
+		if (_requests && _requests.length > client.maxReqQueueCount) {
+			// other feedback strategy
+			return
+		}
+	}
     var req = this.transport.request(options, function(res){
         res.setEncoding('utf8');
         if(res.statusCode >= 200 && res.statusCode < 300) {

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -26,14 +26,15 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
             options[key] = this.options[key];
         }
     }
-	// in case sentry server is down
+	// prevent off heap memory explosion
 	var _agent = options.agent || this.transport.globalAgent;
-	if (!_agent) {
-		_name = client.dsn.host + ":" + client.dsn.port;
-		_requests = _agent.requests[_name];
+	if (_agent) {
+		var _name = client.dsn.host + ":" + client.dsn.port;
+		var _requests = _agent.requests[_name];
 		if (_requests && _requests.length > client.maxReqQueueCount) {
 			// other feedback strategy
-			return
+			client.emit('error', new Error("client req queue is full.."));
+			return;
 		}
 	}
     var req = this.transport.request(options, function(res){


### PR DESCRIPTION
If request is stacking (e.g sentry server is down),  new ClientRequest will be added to agent.requests[]  and each ClientRequest uses Buffer. As clientRequest not consumed, process memory usage will explosive growth even though V8 memory usage is low.
