### PR TITLE
Push optional attributtes to captured error

### DIFF
--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -8,7 +8,7 @@ var connectMiddleware = function(client) {
 
 // Error handler. This should be the last item listed in middleware, but
 // before any other error handlers.
-connectMiddleware.errorHandler = function(client) {
+connectMiddleware.errorHandler = function(client, optionalAttributesHandler) {
     client = (client instanceof raven.Client) ? client : new raven.Client(client);
     return function(err, req, res, next) {
         var status = err.status || err.statusCode || err.status_code || 500;
@@ -17,6 +17,9 @@ connectMiddleware.errorHandler = function(client) {
         if (status < 500) return next(err);
 
         var kwargs = parsers.parseRequest(req);
+        
+        if (optionalAttributesHandler && typeof optionalAttributesHandler == "function") optionalAttributesHandler(kwargs, req, err);
+        
         client.captureError(err, kwargs, function(result) {
             res.sentry = client.getIdent(result);
             next(err, req, res);


### PR DESCRIPTION
Usage:

```javascript
// The request handler be the first item
app.use(raven.middleware.express.requestHandler(sentryDSN));

// The error handler must be before any other error middleware
app.use(raven.middleware.express.errorHandler(sentryDSN, function(attributes, req, error){
	attributes['sentry.interfaces.User'] = req.user;
	attributes.tags = {'env': 'production', 'version': '0.1'}
}));
```