### PR TITLE
Implement global context + add context API methods

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -7,9 +7,20 @@ var uuid = require('node-uuid');
 var transports = require('./transports');
 var node_util = require('util'); // node_util to avoid confusion with "utils"
 var events = require('events');
-var extend = require('extend');
 
 module.exports.version = require('../package.json').version;
+
+var extend = Object.assign || function(target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+  return target;
+};
 
 var Client = function Client(dsn, options) {
   if (arguments.length === 0) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,6 +7,7 @@ var uuid = require('node-uuid');
 var transports = require('./transports');
 var node_util = require('util'); // node_util to avoid confusion with "utils"
 var events = require('events');
+var extend = require('extend');
 
 module.exports.version = require('../package.json').version;
 
@@ -41,6 +42,13 @@ var Client = function Client(dsn, options) {
   // enabled if a dsn is set
   this._enabled = !!this.dsn;
 
+  var globalContext = this._globalContext = {};
+  if (options.tags) {
+    globalContext.tags = options.tags;
+  }
+  if (options.extra) {
+    globalContext.extra = options.extra;
+  }
 
   this.on('error', function(e) {}); // noop
 };
@@ -57,16 +65,23 @@ proto.getIdent =
 proto.process = function process(kwargs) {
   kwargs.modules = utils.getModules();
   kwargs.server_name = kwargs.server_name || this.name;
-  kwargs.extra = kwargs.extra || {};
+
   if (typeof process.version !== 'undefined') {
     kwargs.extra.node = process.version;
   }
-  kwargs.tags = kwargs.tags || {};
+
+  kwargs.extra = extend({}, this._globalContext.extra, kwargs.extra);
+  kwargs.tags = extend({}, this._globalContext.tags, kwargs.tags);
+
   kwargs.logger = kwargs.logger || this.loggerName;
   kwargs.event_id = uuid().replace(/-/g, '');
   kwargs.timestamp = new Date().toISOString().split('.')[0];
   kwargs.project = this.dsn.project_id;
   kwargs.platform = 'node';
+
+  if (this._globalContext.user) {
+    kwargs.user = this._globalContext.user || kwargs.user;
+  }
 
   // Only include release information if it is set
   if (this.release) {
@@ -159,8 +174,41 @@ proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
   return result;
 };
 
+/*
+ * Set/clear a user to be sent along with the payload.
+ *
+ * @param {object} user An object representing user data [optional]
+ * @return {Raven}
+ */
+proto.setUserContext = function setUserContext(user) {
+  this._globalContext.user = user;
+};
+
+/*
+ * Merge extra attributes to be sent along with the payload.
+ *
+ * @param {object} extra An object representing extra data [optional]
+ * @return {Raven}
+ */
+proto.setExtraContext = function setExtraContext(extra) {
+  this._globalContext.extra = extend({}, this._globalContext.extra, extra);
+  return this;
+};
+
+/*
+ * Merge tags to be sent along with the payload.
+ *
+ * @param {object} tags An object representing tags [optional]
+ * @return {Raven}
+ */
+proto.setTagsContext = function setTagsContext(tags) {
+  this._globalContext.tags = extend({}, this._globalContext.tags, tags);
+  return this;
+};
+
 proto.patchGlobal = function patchGlobal(cb) {
   module.exports.patchGlobal(this, cb);
+  return this;
 };
 
 module.exports.patchGlobal = function patchGlobal(client, cb) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -45,16 +45,16 @@ var Client = function Client(dsn, options) {
   this.on('error', function(e) {}); // noop
 };
 node_util.inherits(Client, events.EventEmitter);
-var _ = Client.prototype;
+var proto = Client.prototype;
 
 module.exports.Client = Client;
 
-_.getIdent =
-  _.get_ident = function getIdent(result) {
+proto.getIdent =
+  proto.get_ident = function getIdent(result) {
     return result.id;
   };
 
-_.process = function process(kwargs) {
+proto.process = function process(kwargs) {
   kwargs.modules = utils.getModules();
   kwargs.server_name = kwargs.server_name || this.name;
   kwargs.extra = kwargs.extra || {};
@@ -87,7 +87,7 @@ _.process = function process(kwargs) {
   return ident;
 };
 
-_.send = function send(kwargs, ident) {
+proto.send = function send(kwargs, ident) {
   var self = this;
 
   // stringify, but don't choke on circular references, see: http://stackoverflow.com/questions/11616630/json-stringify-avoid-typeerror-converting-circular-structure-to-json
@@ -113,7 +113,7 @@ _.send = function send(kwargs, ident) {
   });
 };
 
-_.captureMessage = function captureMessage(message, kwargs, cb) {
+proto.captureMessage = function captureMessage(message, kwargs, cb) {
   if (!cb && typeof kwargs === 'function') {
     cb = kwargs;
     kwargs = {};
@@ -125,8 +125,8 @@ _.captureMessage = function captureMessage(message, kwargs, cb) {
   return result;
 };
 
-_.captureError =
-  _.captureException = function captureError(err, kwargs, cb) {
+proto.captureError =
+  proto.captureException = function captureError(err, kwargs, cb) {
     if (!(err instanceof Error)) {
       // This handles when someone does:
       //   throw "something awesome";
@@ -147,7 +147,7 @@ _.captureError =
     });
   };
 
-_.captureQuery = function captureQuery(query, engine, kwargs, cb) {
+proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
   if (!cb && typeof kwargs === 'function') {
     cb = kwargs;
     kwargs = {};
@@ -159,7 +159,7 @@ _.captureQuery = function captureQuery(query, engine, kwargs, cb) {
   return result;
 };
 
-_.patchGlobal = function patchGlobal(cb) {
+proto.patchGlobal = function patchGlobal(cb) {
   module.exports.patchGlobal(this, cb);
 };
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "cookie": "0.1.0",
-    "extend": "~3.0.0",
     "lsmod": "~0.0.3",
     "node-uuid": "~1.4.1",
     "stack-trace": "0.0.7"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   },
   "dependencies": {
     "cookie": "0.1.0",
-    "extend": "^3.0.0",
+    "extend": "~3.0.0",
     "lsmod": "~0.0.3",
     "node-uuid": "~1.4.1",
     "stack-trace": "0.0.7"
   },
   "devDependencies": {
-    "coffee-script": "^1.10.0",
+    "coffee-script": "~1.10.0",
     "connect": "*",
     "eslint": "1.10.3",
     "express": "*",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "cookie": "0.1.0",
+    "extend": "^3.0.0",
     "lsmod": "~0.0.3",
     "node-uuid": "~1.4.1",
     "stack-trace": "0.0.7"


### PR DESCRIPTION
Fixes #134, refs #83

Adds 3 new public methods, whose signatures matches the equivalent methods raven-js:
* `setUserContext`
* `setExtraContext`
* `setTagsContext`

Additionally, `extra` and `tags` can be specified during client initialization (again, like raven-js):

```javascript
var client = new raven.Client('DSN', {
  extra: { foo: 'bar' },
  tags: { browser: 'Chrome 46.0' }
});
```

Note that `user` cannot be specified via `raven.Client` – for no particular reason, other than that's what raven-js does and I'm trying to be as consistent as possible with that library.