### PR TITLE
Update lsmod to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "cookie": "0.1.0",
-    "lsmod": "~0.0.3",
+    "lsmod": "1.0.0",
     "node-uuid": "~1.4.1",
     "stack-trace": "0.0.7"
   },


### PR DESCRIPTION
This is for issue #152 to handle a null exception if no node modules are loaded (required).