### PR TITLE
Coerce error.name to string before assigning as type (fixes #155)

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -13,11 +13,12 @@ module.exports.parseText = function parseText(message, kwargs) {
 
 module.exports.parseError = function parseError(err, kwargs, cb) {
   utils.parseStack(err, function(frames) {
+    var name = err.name + '';
     if (typeof kwargs.message === 'undefined') {
-      kwargs.message = err.name + ': ' + (err.message || '<no message>');
+      kwargs.message = name + ': ' + (err.message || '<no message>');
     }
     kwargs.exception = [{
-      type: err.name,
+      type: name,
       value: err.message,
       stacktrace: {
         frames: frames
@@ -36,7 +37,7 @@ module.exports.parseError = function parseError(err, kwargs, cb) {
     }
     if (extraErrorProps) {
       kwargs.extra = kwargs.extra || {};
-      kwargs.extra[err.name] = extraErrorProps;
+      kwargs.extra[name] = extraErrorProps;
     }
 
     for (var n = frames.length - 1; n >= 0; n--) {

--- a/test/raven.parsers.js
+++ b/test/raven.parsers.js
@@ -445,6 +445,19 @@ describe('raven.parsers', function() {
       });
     });
 
+    it('should parse Error with non-string type', function(done) {
+      var err = new Error();
+      err.name = {};
+      raven.parsers.parseError(err, {}, function(parsed) {
+        parsed.message.should.equal('[object Object]: <no message>');
+        parsed.should.have.property('exception');
+        parsed.exception[0].type.should.equal('[object Object]');
+        parsed.exception[0].value.should.equal('');
+        parsed.exception[0].stacktrace.should.have.property('frames');
+        done();
+      });
+    });
+
     it('should parse thrown Error', function(done) {
       try {
         throw new Error('Derp');


### PR DESCRIPTION
cc @mattrobenolt @dcramer 