### PR TITLE
Add code coverage in test suit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules
 npm-debug.log
 
 working/
+coverage/

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "pretest": "npm install && npm run lint",
-    "test": "NODE_ENV=test mocha --reporter dot && NODE_ENV=test node_modules/coffee-script/bin/coffee ./test/run.coffee",
+    "test": "NODE_ENV=test istanbul cover _mocha  -- --reporter dot && NODE_ENV=test node_modules/coffee-script/bin/coffee ./test/run.coffee",
     "lint": "node_modules/eslint/bin/eslint.js ."
   },
   "engines": {
@@ -37,6 +37,7 @@
     "eslint": "1.10.3",
     "express": "*",
     "glob": "~3.1.13",
+    "istanbul": "^0.4.3",
     "koa": "*",
     "mocha": "*",
     "mock-udp": "*",


### PR DESCRIPTION
Adding [istanbul](https://gotwarlost.github.io/istanbul/) for code coverage. After that a good idea can be add a badge about the test code coverage percentage in the repository (using services such as [https://coveralls.io/](https://coveralls.io/) ).

Opinions? Suggestions? Concerns ?