### PR TITLE
Removes unnecesary single quotes in keys

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -100,7 +100,7 @@ proto.process = function process(kwargs) {
   }
 
   var ident = {
-    'id': kwargs.event_id
+    id: kwargs.event_id
   };
 
   if (this.dataCallback) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,8 +9,8 @@ var lsmod = require('lsmod');
 var stacktrace = require('stack-trace');
 
 var protocolMap = {
-  'http': 80,
-  'https': 443
+  http: 80,
+  https: 443
 };
 
 module.exports.getAuthHeader = function getAuthHeader(timestamp, api_key, api_secret) {


### PR DESCRIPTION
Removing unnecessary single quotes in keys for objects. It's unnecessary because the keys don't have any special characters, so we can use JSON notation for them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/164)
<!-- Reviewable:end -->
