### PR TITLE
Use correct SPDX license expression syntax for BSD license

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "version": "0.11.0",
   "repository": "git://github.com/getsentry/raven-node.git",
   "author": "Matt Robenolt <matt@ydekproductions.com>",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "main": "index",
   "bin": {
     "raven": "./bin/raven"


### PR DESCRIPTION
This PR updates the `license` property in `pacakge.json` with the currect SPDX license expression syntax for the BSD license for this project `BSD-2-Clause`:

```
npm info package.json raven@0.11.0 license should be a valid SPDX license expression
```