### PR TITLE
Coverage directory shouldn't be linted

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage/


### PR DESCRIPTION
As it stands if you try to `npm test` twice in a row while the `coverage/` directory still exists, eslint will attempt to lint all of the `*.js` files in the `coverage/` directory and gets very red very quickly. I'm guessing this isn't desired behavior!

I'm not convinced my solution here is the best one, but it does seem to do what I'd expect it to.