### PR TITLE
Whitelist passed process.env variables

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -11,6 +11,17 @@ module.exports.parseText = function parseText(message, kwargs) {
   return kwargs;
 };
 
+var whitelistEnvironment = function whitelistEnvironment() {
+  return {
+    'REMOTE_ADDR': process.env.REMOTE_ADDR,
+    'SERVER_NAME': process.env.SERVER_NAME,
+    'SERVER_PORT': process.env.SERVER_PORT,
+    'NODE_ENV': process.env.NODE_ENV
+  }
+};
+
+module.exports.whitelistEnvironment = whitelistEnvironment;
+
 module.exports.parseError = function parseError(err, kwargs, cb) {
   utils.parseStack(err, function(frames) {
     var name = err.name + '';
@@ -157,7 +168,7 @@ module.exports.parseRequest = function parseRequest(req, kwargs) {
     cookies: cookies,
     data: data,
     url: url,
-    env: process.env
+    env: whitelistEnvironment()
   };
 
   // add remote ip

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debugging",
     "exceptions"
   ],
-  "version": "0.11.0",
+  "version": "0.11.0-env",
   "repository": "git://github.com/getsentry/raven-node.git",
   "author": "Matt Robenolt <matt@ydekproductions.com>",
   "license": "BSD-2-Clause",

--- a/test/raven.parsers.js
+++ b/test/raven.parsers.js
@@ -33,6 +33,17 @@ describe('raven.parsers', function() {
     });
   });
 
+  describe('#whitelistEnvironment', function() {
+    it('should whitelist all env variables by neccessary ones', function() {
+      var whiteList = raven.parsers.whitelistEnvironment();
+      Object.keys(whiteList).should.have.lengthOf(4);
+      whiteList.should.have.property('REMOTE_ADDR');
+      whiteList.should.have.property('SERVER_NAME');
+      whiteList.should.have.property('SERVER_PORT');
+      whiteList.should.have.property('NODE_ENV');
+    });
+  });
+
   describe('#parseRequest()', function() {
     it('should parse a request object', function() {
       var mockReq = {


### PR DESCRIPTION
It creates a security hole if you pass init variables to your application through environment. If any security tokens are used, raven passes them through, which is an undesired behavior. 
