### PR TITLE
Whitelist passed process.env variables

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -157,11 +157,11 @@ module.exports.parseRequest = function parseRequest(req, kwargs) {
     cookies: cookies,
     data: data,
     url: url,
-    env: process.env
+    env: {
+      NODE_ENV: process.env.NODE_ENV,
+      REMOTE_ADDR: ip
+    }
   };
-
-  // add remote ip
-  http.env.REMOTE_ADDR = ip;
 
   // expose http interface
   kwargs.request = http;


### PR DESCRIPTION
It creates a security hole if you pass init variables to your application through environment. If any security tokens are used, raven passes them through, which is an undesired behavior.

