### PR TITLE
Add support for 'code' field to skip client errors

### DIFF
--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -13,7 +13,7 @@ var connectMiddleware = function(client) {
 connectMiddleware.errorHandler = function(client) {
   client = client instanceof raven.Client ? client : new raven.Client(client);
   return function(err, req, res, next) {
-    var status = err.status || err.statusCode || err.status_code || 500;
+    var status = err.status || err.code || err.statusCode || err.status_code || 500;
 
     // skip anything not marked as an internal server error
     if (status < 500) return next(err);


### PR DESCRIPTION
We use 'code' as name for status codes in our API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/173)
<!-- Reviewable:end -->
