### PR TITLE
add cookie to request headers

### DIFF
--- a/lib/transports.js
+++ b/lib/transports.js
@@ -24,7 +24,9 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
     ca: client.ca
   };
   for (var key in this.options) {
-    if (this.options.hasOwnProperty(key)) {
+    if (this.options.hasOwnProperty('cookie')) {
+      options.headers['Cookie'] = this.options.cookie;
+    } else if (this.options.hasOwnProperty(key)) {
       options[key] = this.options[key];
     }
   }

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -24,12 +24,15 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
     ca: client.ca
   };
   for (var key in this.options) {
-    if (this.options.hasOwnProperty('cookie')) {
-      options.headers['Cookie'] = this.options.cookie;
-    } else if (this.options.hasOwnProperty(key)) {
+    if (this.options.hasOwnProperty(key)) {
       options[key] = this.options[key];
     }
   }
+
+  if (options.hasOwnProperty('cookie')) {
+    options.headers['Cookie'] = options.cookie;
+  }
+
   var req = this.transport.request(options, function(res) {
     res.setEncoding('utf8');
     if (res.statusCode >= 200 && res.statusCode < 300) {


### PR DESCRIPTION
Needed a way to send cookie headers in the http request.  There may be a better or existing way to solve this cleanly but this pull allows for some config like this...

```
var ravenClient = new raven.Client(SENTRY_DSN, {
    level: 'error',
    transport: new raven.transports.HTTPSTransport({ cookie: 'blah=blah; blah2=blah2' })
});
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/174)

<!-- Reviewable:end -->
