### PR TITLE
Pass result of captureException-attempt to patchGlobal callback

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -237,14 +237,14 @@ module.exports.patchGlobal = function patchGlobal(client, cb) {
   var called = false;
   process.on('uncaughtException', function(err) {
     if (cb) { // bind event listeners only if a callback was supplied
-      var onLogged = function onLogged() {
+      var onLogged = function onLogged(result) {
         called = false;
-        cb(true, err);
+        cb(true, err, result);
       };
 
-      var onError = function onError() {
+      var onError = function onError(result) {
         called = false;
-        cb(false, err);
+        cb(false, err, result);
       };
 
       if (called) {


### PR DESCRIPTION
Any reason it doesn't do this today?

Seems handy - could pass crash report ID to user in the error dialog or otherwise log, no?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/180)

<!-- Reviewable:end -->
