### PR TITLE
Drop process.env, pass IP as User interface (refs #58, #169, #170)

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -156,12 +156,8 @@ module.exports.parseRequest = function parseRequest(req, kwargs) {
     headers: headers,
     cookies: cookies,
     data: data,
-    url: url,
-    env: process.env
+    url: url
   };
-
-  // add remote ip
-  http.env.REMOTE_ADDR = ip;
 
   // expose http interface
   kwargs.request = http;
@@ -171,12 +167,14 @@ module.exports.parseRequest = function parseRequest(req, kwargs) {
   // typically found on req.user according to Express and Passport
 
   var user = {};
-  if (req.user && !kwargs.user) {
-    // shallow copy is okay because we are only modifying top-level
-    // object (req.user)
-    for (var key in req.user) {
-      if ({}.hasOwnProperty.call(req.user, key)) {
-        user[key] = req.user[key];
+  if (!kwargs.user) {
+    if (req.user) {
+      // shallow copy is okay because we are only modifying top-level
+      // object (req.user)
+      for (var key in req.user) {
+        if ({}.hasOwnProperty.call(req.user, key)) {
+          user[key] = req.user[key];
+        }
       }
     }
 

--- a/test/raven.parsers.js
+++ b/test/raven.parsers.js
@@ -53,8 +53,7 @@ describe('raven.parsers', function() {
       var parsed = raven.parsers.parseRequest(mockReq);
       parsed.should.have.property('request');
       parsed.request.url.should.equal('https://mattrobenolt.com/some/path?key=value');
-      parsed.request.env.NODE_ENV.should.equal(process.env.NODE_ENV);
-      parsed.request.env.REMOTE_ADDR.should.equal('127.0.0.1');
+      parsed.user.ip_address.should.equal('127.0.0.1');
     });
 
     describe('`headers` detection', function() {
@@ -308,7 +307,7 @@ describe('raven.parsers', function() {
 
         var parsed = raven.parsers.parseRequest(mockReq);
 
-        parsed.request.env.REMOTE_ADDR.should.equal('127.0.0.1');
+        parsed.user.ip_address.should.equal('127.0.0.1');
       });
 
       it('should detect ip via `req.connection.remoteAddress`', function() {
@@ -325,7 +324,7 @@ describe('raven.parsers', function() {
 
         var parsed = raven.parsers.parseRequest(mockReq);
 
-        parsed.request.env.REMOTE_ADDR.should.equal('127.0.0.1');
+        parsed.user.ip_address.should.equal('127.0.0.1');
       });
     });
 


### PR DESCRIPTION
This mimics the behavior from raven-python and other clients.

cc @macqueen @mattrobenolt @psergus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/181)
<!-- Reviewable:end -->
