### PR TITLE
Use json-stringify-safe to prevent circular references (refs #102)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var stringify = require('json-stringify-safe');
 var parsers = require('./parsers');
 var zlib = require('zlib');
 var utils = require('./utils');
@@ -116,16 +117,8 @@ proto.process = function process(kwargs) {
 
 proto.send = function send(kwargs, ident) {
   var self = this;
-
-  // stringify, but don't choke on circular references, see: http://stackoverflow.com/questions/11616630/json-stringify-avoid-typeerror-converting-circular-structure-to-json
-  var cache = [];
-  var skwargs = JSON.stringify(kwargs, function(k, v) {
-    if (typeof v === 'object' && v !== null) {
-      if (cache.indexOf(v) !== -1) return;
-      cache.push(v);
-    }
-    return v;
-  });
+  
+  var skwargs = stringify(kwargs);
 
   zlib.deflate(skwargs, function(err, buff) {
     var message = buff.toString('base64'),

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -2,6 +2,8 @@
 
 var cookie = require('cookie');
 var urlParser = require('url');
+var stringify = require('json-stringify-safe');
+
 var utils = require('./utils');
 
 module.exports.parseText = function parseText(message, kwargs) {
@@ -138,7 +140,7 @@ module.exports.parseRequest = function parseRequest(req, kwargs) {
 
   if (data && {}.toString.call(data) !== '[object String]') {
     // Make sure the request body is a string
-    data = JSON.stringify(data);
+    data = stringify(data);
   }
 
   // client ip:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "cookie": "0.1.0",
+    "json-stringify-safe": "^5.0.1",
     "lsmod": "1.0.0",
     "node-uuid": "~1.4.1",
     "stack-trace": "0.0.7"


### PR DESCRIPTION
We're using this in raven-js, might as well use here too.

cc @macqueen @mattrobenolt 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/182)
<!-- Reviewable:end -->
