### PR TITLE
Add Transport Callbacks (#196)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -75,7 +75,7 @@ proto.getIdent =
     return result.id;
   };
 
-proto.process = function process(kwargs) {
+proto.process = function process(kwargs, cb) {
   kwargs.modules = utils.getModules();
   kwargs.server_name = kwargs.server_name || this.name;
 
@@ -110,15 +110,19 @@ proto.process = function process(kwargs) {
     kwargs = this.dataCallback(kwargs);
   }
 
+  function callback() {
+    cb && cb(ident);
+  }
+
   // this will happen asynchronously. We don't care about it's response.
-  this._enabled && this.send(kwargs, ident);
+  this._enabled && this.send(kwargs, ident, callback);
 
   return ident;
 };
 
 proto.send = function send(kwargs, ident) {
   var self = this;
-  
+
   var skwargs = stringify(kwargs);
 
   zlib.deflate(skwargs, function(err, buff) {
@@ -141,8 +145,7 @@ proto.captureMessage = function captureMessage(message, kwargs, cb) {
   } else {
     kwargs = kwargs || {};
   }
-  var result = this.process(parsers.parseText(message, kwargs));
-  cb && cb(result);
+  var result = this.process(parsers.parseText(message, kwargs), cb);
   return result;
 };
 
@@ -162,8 +165,7 @@ proto.captureException = function captureError(err, kwargs, cb) {
     kwargs = kwargs || {};
   }
   parsers.parseError(err, kwargs, function(kw) {
-    var result = self.process(kw);
-    cb && cb(result);
+    self.process(kw, cb);
   });
 };
 proto.captureError = proto.captureException; // legacy alias
@@ -175,8 +177,8 @@ proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
   } else {
     kwargs = kwargs || {};
   }
-  var result = this.process(parsers.parseQuery(query, engine, kwargs));
-  cb && cb(result);
+  var result = this.process(parsers.parseQuery(query, engine, kwargs, cb));
+
   return result;
 };
 

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -14,7 +14,7 @@ function HTTPTransport(options) {
   this.options = options || {};
 }
 util.inherits(HTTPTransport, Transport);
-HTTPTransport.prototype.send = function(client, message, headers, ident) {
+HTTPTransport.prototype.send = function(client, message, headers, ident, cb) {
   var options = {
     hostname: client.dsn.host,
     path: client.dsn.path + 'api/' + client.dsn.project_id + '/store/',
@@ -46,7 +46,9 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
     // force the socket to drain
     var noop = function() {};
     res.on('data', noop);
-    res.on('end', noop);
+    res.on('end', function() {
+      cb && cb();
+    });
   });
   req.on('error', function(e) {
     client.emit('error', e);
@@ -69,7 +71,7 @@ function UDPTransport() {
   this.defaultPort = 12345;
 }
 util.inherits(UDPTransport, Transport);
-UDPTransport.prototype.send = function(client, message, headers, ident) {
+UDPTransport.prototype.send = function(client, message, headers, ident, cb) {
   message = new Buffer(headers['X-Sentry-Auth'] + '\n\n' + message);
 
   var udp = dgram.createSocket('udp4');
@@ -79,6 +81,7 @@ UDPTransport.prototype.send = function(client, message, headers, ident) {
     }
     client.emit('logged', ident);
     udp.close();
+    cb && cb();
   });
 };
 


### PR DESCRIPTION
In some cases the node process will exit before the request is sent. This is the case when using AWS Lambda. I am proposing that there is a callback added to the transports, which is called only after the request is complete.

``` js
client.captureException(new Error('oh no'), function() {
  // Async request is complete
  done(); // exit process
});
```

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/200)

<!-- Reviewable:end -->
