### PR TITLE
Add Basic Breadcrumbs Support

### DIFF
--- a/lib/breadcrumbs.js
+++ b/lib/breadcrumbs.js
@@ -2,7 +2,9 @@
 
 var BreadcrumbBuffer = function BreadcrumbBuffer(maxBreadcrumbs) {
   this._buffer = [];
-  this._maxBreadcrums = maxBreadcrumbs;
+  this._globalOptions = {
+    maxBreadcrumbs: maxBreadcrumbs
+  };
 };
 
 BreadcrumbBuffer.prototype.add = function add(crumb) {

--- a/lib/breadcrumbs.js
+++ b/lib/breadcrumbs.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var BreadcrumbBuffer = function BreadcrumbBuffer(maxBreadcrumbs) {
+  this._buffer = [];
+  this._maxBreadcrums = maxBreadcrumbs;
+};
+
+BreadcrumbBuffer.prototype.add = function add(crumb) {
+  this._buffer.push(crumb);
+  if (this._buffer.length > this._globalOptions.maxBreadcrumbs) {
+    this._buffer.shift();
+  }
+}
+
+BreadcrumbBuffer.prototype.fetch = function fetch() {
+  var rv = this._buffer;
+  this._buffer = [];
+  return rv;
+}
+
+module.exports.BreadcrumbBuffer = BreadcrumbBuffer;

--- a/lib/client.js
+++ b/lib/client.js
@@ -12,17 +12,7 @@ var events = require('events');
 
 module.exports.version = require('../package.json').version;
 
-var extend = Object.assign || function(target) {
-  for (var i = 1; i < arguments.length; i++) {
-    var source = arguments[i];
-    for (var key in source) {
-      if (Object.prototype.hasOwnProperty.call(source, key)) {
-        target[key] = source[key];
-      }
-    }
-  }
-  return target;
-};
+var extend = utils.extend;
 
 var Client = function Client(dsn, options) {
   if (arguments.length === 0) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,7 @@ var zlib = require('zlib');
 var utils = require('./utils');
 var uuid = require('node-uuid');
 var transports = require('./transports');
+var localContext = require('./localContext');
 var node_util = require('util'); // node_util to avoid confusion with "utils"
 var events = require('events');
 
@@ -55,6 +56,9 @@ var Client = function Client(dsn, options) {
   // enabled if a dsn is set
   this._enabled = !!this.dsn;
 
+  // the global context is somewhat internal however when a local context
+  // is created these attributes are copied over.  see `LocalContext` for
+  // more information.
   var globalContext = this._globalContext = {};
   if (options.tags) {
     globalContext.tags = options.tags;
@@ -69,6 +73,15 @@ node_util.inherits(Client, events.EventEmitter);
 var proto = Client.prototype;
 
 module.exports.Client = Client;
+
+module.exports.captureBreadcrumb = function(crumb) {
+  var context = localContext.contextManager.getContext();
+  if (context) {
+    context.captureBreadcrumb(crumb);
+    return true;
+  }
+  return false;
+};
 
 proto.getIdent =
   proto.get_ident = function getIdent(result) {
@@ -180,6 +193,50 @@ proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
   return result;
 };
 
+/* captures a breadcrumb.  This function does nothing in case no local
+ * context is available and will return `false`.  More commonly the global
+ * `captureBreadcrumb` function would be called which directly routes to a
+ * client.
+ */
+proto.captureBreadcrumb = function captureBreadcrumb(crumb) {
+  var context = this.getLocalContext();
+  if (context) {
+    context.captureBreadcrumb(crumb);
+    return true;
+  }
+  return false;
+};
+
+/*
+ * Returns the local context.  In case the local context integration is
+ * not configured this can return `null`.
+ */
+proto.getLocalContext = function getLocalContext() {
+  return localContext.contextManager.getOrCreateContext(this);
+};
+
+/*
+ * Runs the given function enclosed in a local context.  This means that
+ * code enclosed by this can at any point call `Client.getCurrent()` to
+ * get the current client and `client.getLocalContext()` to retrieve the
+ * local context object.
+ *
+ * This is used for breadcrumbs support and similar functionality.
+ */
+proto.runWithLocalContext = function(fn) {
+  return localContext.contextManager.runWithContext(this, fn);
+}
+
+/*
+ * When the client's local context integration is used this returns the
+ * current client.  In case the local context integration is not configured
+ * this can return `null`.
+ */
+Client.getCurrent = function() {
+  var rv = localContext.contextManager.getContext();
+  return rv && rv.client || null;
+}
+
 /*
  * Set/clear a user to be sent along with the payload.
  *
@@ -187,7 +244,8 @@ proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
  * @return {Raven}
  */
 proto.setUserContext = function setUserContext(user) {
-  this._globalContext.user = user;
+  var ctx = this.getLocalContext() || this._globalContext;
+  ctx.user = user;
 };
 
 /*
@@ -197,7 +255,8 @@ proto.setUserContext = function setUserContext(user) {
  * @return {Raven}
  */
 proto.setExtraContext = function setExtraContext(extra) {
-  this._globalContext.extra = extend({}, this._globalContext.extra, extra);
+  var ctx = this.getLocalContext() || this._globalContext;
+  ctx.extra = extend({}, ctx.extra, extra);
   return this;
 };
 
@@ -208,7 +267,8 @@ proto.setExtraContext = function setExtraContext(extra) {
  * @return {Raven}
  */
 proto.setTagsContext = function setTagsContext(tags) {
-  this._globalContext.tags = extend({}, this._globalContext.tags, tags);
+  var ctx = this.getLocalContext() || this._globalContext;
+  ctx.tags = extend({}, ctx.tags, tags);
   return this;
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -89,6 +89,8 @@ proto.getIdent =
   };
 
 proto.process = function process(kwargs) {
+  var localCtx = localContext.contextManager.getContext();
+  var ctx = localCtx || this._globalContext;
   kwargs.modules = utils.getModules();
   kwargs.server_name = kwargs.server_name || this.name;
 
@@ -97,17 +99,20 @@ proto.process = function process(kwargs) {
   }
 
   kwargs.environment = kwargs.environment || this.environment;
-  kwargs.extra = extend({}, this._globalContext.extra, kwargs.extra);
-  kwargs.tags = extend({}, this._globalContext.tags, kwargs.tags);
+  kwargs.extra = extend({}, ctx.extra, kwargs.extra);
+  kwargs.tags = extend({}, ctx.tags, kwargs.tags);
 
   kwargs.logger = kwargs.logger || this.loggerName;
   kwargs.event_id = uuid().replace(/-/g, '');
   kwargs.timestamp = new Date().toISOString().split('.')[0];
   kwargs.project = this.dsn.project_id;
   kwargs.platform = 'node';
+  if (localCtx) {
+    kwargs.breadcrumbs = localCtx.breadcrumbs.fetch();
+  }
 
-  if (this._globalContext.user) {
-    kwargs.user = this._globalContext.user || kwargs.user;
+  if (ctx.user) {
+    kwargs.user = ctx.user || kwargs.user;
   }
 
   // Only include release information if it is set

--- a/lib/localContext.js
+++ b/lib/localContext.js
@@ -43,14 +43,16 @@ ContextManager.prototype.getOrCreateContext = function getOrCreateContext(client
 };
 
 ContextManager.prototype.runWithContext = function(client, fn) {
-  return ctxNamespace.runAndReturn(function() {
+  var rv;
+  ctxNamespace.run(function() {
     // if we run this way we make sure we absolutely create a new
     // local context here because otherwise things like the
     // global `captureBreadcrumb` function would not be able to
     // find a client.
     ctxNamespace.set('localContext', new LocalContext(client));
-    return fn();
+    rv = fn();
   });
+  return rv;
 };
 
 var contextManager = new ContextManager();

--- a/lib/localContext.js
+++ b/lib/localContext.js
@@ -2,6 +2,8 @@
 
 var createNamespace = require('continuation-local-storage').createNamespace;
 var breadcrumbs = require('./breadcrumbs');
+var utils = require('./utils');
+var extend = utils.extend;
 
 var ctxNamespace = createNamespace('ravenLocalContext');
 
@@ -13,12 +15,12 @@ var LocalContext = function LocalContext(client) {
 
   // when we make the local context we copy over the global context.
   this.user = client._globalContext.user;
-  this.extra = Object.assign({}, client._globalContext.extra || {});
-  this.tags = Object.assign({}, client._globalContext.tags || {});
+  this.extra = extend({}, client._globalContext.extra || {});
+  this.tags = extend({}, client._globalContext.tags || {});
 };
 
 LocalContext.prototype.captureBreadcrumb = function captureBreadcrumb(crumb) {
-  this.breadcrumbs.add(Object.assign({
+  this.breadcrumbs.add(extend({
     timestamp: +new Date() / 1000
   }, crumb));
 };

--- a/lib/localContext.js
+++ b/lib/localContext.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var createNamespace = require('continuation-local-storage').createNamespace;
+var breadcrumbs = require('./breadcrumbs');
+
+var ctxNamespace = createNamespace('ravenLocalContext');
+
+
+var LocalContext = function LocalContext(client) {
+  this.client = client;
+  this.breadcrumbs = new breadcrumbs.BreadcrumbBuffer(
+    client._globalContext.maxBreadcrumbs);
+
+  // when we make the local context we copy over the global context.
+  this.user = client._globalContext.user;
+  this.extra = Object.assign({}, client._globalContext.extra || {});
+  this.tags = Object.assign({}, client._globalContext.tags || {});
+};
+
+LocalContext.prototype.captureBreadcrumb = function captureBreadcrumb(crumb) {
+  this.breadcrumbs.add(Object.assign({
+    timestamp: +new Date() / 1000
+  }, crumb));
+};
+
+var ContextManager = function ContextManager() {
+};
+
+ContextManager.prototype.getContext = function getContext(client) {
+  return ctxNamespace.get('localContext') || null;
+};
+
+ContextManager.prototype.getOrCreateContext = function getOrCreateContext(client) {
+  if (!ctxNamespace.active) {
+    return null;
+  }
+  var rv = ctxNamespace.get('localContext');
+  if (!rv) {
+    rv = new LocalContext(client);
+    ctxNamespace.set('localContext', rv);
+  }
+  return rv;
+};
+
+ContextManager.prototype.runWithContext = function(client, fn) {
+  return ctxNamespace.runAndReturn(function() {
+    // if we run this way we make sure we absolutely create a new
+    // local context here because otherwise things like the
+    // global `captureBreadcrumb` function would not be able to
+    // find a client.
+    ctxNamespace.set('localContext', new LocalContext(client));
+    return fn();
+  });
+};
+
+var contextManager = new ContextManager();
+
+module.exports.LocalContext = LocalContext;
+module.exports.contextManager = contextManager;

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -33,7 +33,9 @@ connectMiddleware.requestHandler = function(client) {
   return function(req, res, next) {
     var reqDomain = domain.create();
     reqDomain.on('error', next);
-    return reqDomain.run(next);
+    return client.runWithLocalContext(function() {
+      return reqDomain.run(next);
+    });
   };
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,18 @@ var protocolMap = {
   https: 443
 };
 
+module.exports.extend = Object.assign || function(target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+  return target;
+};
+
 module.exports.getAuthHeader = function getAuthHeader(timestamp, api_key, api_secret) {
   var header = ['Sentry sentry_version=5'];
   header.push('sentry_timestamp=' + timestamp);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
+    "continuation-local-storage": "^3.1.7",
     "cookie": "0.1.0",
     "json-stringify-safe": "^5.0.1",
     "lsmod": "1.0.0",

--- a/test/raven.breadcrumbs.js
+++ b/test/raven.breadcrumbs.js
@@ -1,0 +1,26 @@
+/*eslint no-shadow:0*/
+'use strict';
+
+var assert = require('assert');
+
+var raven = require('../');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+describe('raven.Client', function() {
+  var client;
+
+  beforeEach(function() {
+    client = new raven.Client(dsn);
+  });
+
+  it('should manage contexts', function() {
+    client.runWithLocalContext(function() {
+      var ctx = client.getLocalContext();
+      assert(ctx !== null);
+      ctx.client.should.eql(client);
+    });
+
+    var ctx = client.getLocalContext();
+    assert(ctx === null);
+  });
+});


### PR DESCRIPTION
This pull request adds basic support for local contexts and the machinery for breadcrumbs to raven-node. In particular the local context fixes some issues with concurrency for the current context handling which is not great.

There are more questions about how this is supposed to work so do not merge it yet.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/203)

<!-- Reviewable:end -->
