### PR TITLE
Update eslint to 2.13.1, make eslintrc more strict

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,62 +3,86 @@
     "node": true,
     "mocha": true,
   },
+  "extends": "eslint:recommended",
   "rules": {
+    "array-bracket-spacing": [2, "never"],
     "block-scoped-var": 2,
-    "dot-notation": [
-      2,
-      {
-        "allowKeywords": true
-      }
-    ],
-    "eqeqeq": [
-      2,
-      "allow-null"
-    ],
+    "brace-style": [2, "1tbs"],
+    "camelcase": [1, "properties": "never"],
+    "comma-dangle": 0,
+    "comma-spacing": [2, {"before": false, "after": true}],
+    "comma-style": [2, "last"],
+    "computed-property-spacing": [2, "never"],
+    "consistent-return": 2,
+    "consistent-this": [2, "self"],
+    "curly": [2, "multi-line"],
+    "default-case": 2,
+    "dot-notation": 2,
+    "eol-last": 2,
+    "eqeqeq": [2, "allow-null"],
     "guard-for-in": 2,
+    "indent": [2, 2, {"SwitchCase": 1, "VariableDeclarator": { "var": 2, "let": 2, "const": 3}}],
+    "key-spacing": [1, {"beforeColon": false, "afterColon": true}],
+    "keyword-spacing": 2,
+    "max-len": [1, 120],
     "new-cap": 2,
+    "no-alert": 2,
     "no-caller": 2,
-    "no-cond-assign": [
-      2,
-      "except-parens"
-    ],
+    "no-catch-shadow": 1,
+    "no-console": 1,
     "no-debugger": 2,
-    "no-empty": 2,
+    "no-else-return": 2,
+    "no-empty": [2, {"allowEmptyCatch": true}],
     "no-eval": 2,
+    "no-extra-bind": 2,
     "no-extend-native": 2,
     "no-extra-parens": 2,
-    "no-irregular-whitespace": 2,
+    "no-fallthrough": 2,
+    "no-floating-decimal": 2,
+    "no-implied-eval": 2,
+    "no-inner-declarations": 2,
     "no-iterator": 2,
+    "no-lonely-if": 2,
     "no-loop-func": 2,
+    "no-mixed-spaces-and-tabs": 2,
+    "no-multiple-empty-lines": [2, {"max": 2}],
+    "no-multi-spaces": 2,
     "no-multi-str": 2,
     "no-new": 2,
+    "no-param-reassign": 1,
     "no-proto": 2,
+    "no-redeclare": 2,
+    "no-return-assign": 2,
     "no-script-url": 2,
+    "no-self-compare": 2,
     "no-sequences": 2,
     "no-shadow": 2,
+    "no-shadow-restricted-names": 2,
+    "no-spaced-func": 2,
+    "no-trailing-spaces": 2,
     "no-undef": 2,
-    "no-unused-vars": [
-      2,
-      {"args": "none"}
-    ],
+    "no-undefined": 2,
+    "no-underscore-dangle": 0,
+    "no-unused-vars": [2, {"vars": "all", "args": "none"}],
+    "no-use-before-define": [2, "nofunc"],
+    "no-useless-call": 2,
+    "no-useless-escape": 2,
+    "no-warning-comments": 0,
     "no-with": 2,
-    "quotes": [
-      2,
-      "single",
-      "avoid-escape"
-    ],
-    "semi": [
-      0,
-      "never"
-    ],
-    "strict": [
-      2,
-      "global"
-    ],
+    "object-curly-spacing": [2, "always"],
+    "quotes": [2, "single", "avoid-escape"],
+    "semi": [2, "always"],
+    "semi-spacing": [2, {"before": false, "after": true}],
+    "space-before-blocks": 2,
+    "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
+    "space-in-parens": 2,
+    "space-infix-ops": 2,
+    "space-unary-ops": 2,
+    "spaced-comment": [2, "always"],
+    "strict": [2, "global"],
+    "valid-jsdoc": 0,
     "valid-typeof": 2,
-    "wrap-iife": [
-      2,
-      "inside"
-    ]
+    "wrap-iife": [2, "inside"],
+    "yoda": [2, "never"]
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 module.exports = require('./lib/client');
 module.exports.utils = require('./lib/utils');
 module.exports.middleware = {
-    connect: require('./lib/middleware/connect')
+  connect: require('./lib/middleware/connect')
 };
 // friendly alias for "raven.middleware.express"
 module.exports.middleware.express = module.exports.middleware.connect;

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,12 +6,12 @@ var zlib = require('zlib');
 var utils = require('./utils');
 var uuid = require('node-uuid');
 var transports = require('./transports');
-var node_util = require('util'); // node_util to avoid confusion with "utils"
+var nodeUtil = require('util'); // nodeUtil to avoid confusion with "utils"
 var events = require('events');
 
 module.exports.version = require('../package.json').version;
 
-var extend = Object.assign || function(target) {
+var extend = Object.assign || function (target) {
   for (var i = 1; i < arguments.length; i++) {
     var source = arguments[i];
     for (var key in source) {
@@ -63,9 +63,9 @@ var Client = function Client(dsn, options) {
     globalContext.extra = options.extra;
   }
 
-  this.on('error', function(e) {}); // noop
+  this.on('error', function (e) {}); // noop
 };
-node_util.inherits(Client, events.EventEmitter);
+nodeUtil.inherits(Client, events.EventEmitter);
 var proto = Client.prototype;
 
 module.exports.Client = Client;
@@ -110,7 +110,7 @@ proto.process = function process(kwargs) {
     kwargs = this.dataCallback(kwargs);
   }
 
-  // this will happen asynchronously. We don't care about it's response.
+  // this will happen asynchronously. We don't care about its response.
   this._enabled && this.send(kwargs, ident);
 
   return ident;
@@ -118,17 +118,17 @@ proto.process = function process(kwargs) {
 
 proto.send = function send(kwargs, ident) {
   var self = this;
-  
+
   var skwargs = stringify(kwargs);
 
-  zlib.deflate(skwargs, function(err, buff) {
+  zlib.deflate(skwargs, function (err, buff) {
     var message = buff.toString('base64'),
-      timestamp = new Date().getTime(),
-      headers = {
-        'X-Sentry-Auth': utils.getAuthHeader(timestamp, self.dsn.public_key, self.dsn.private_key),
-        'Content-Type': 'application/octet-stream',
-        'Content-Length': message.length
-      };
+        timestamp = new Date().getTime(),
+        headers = {
+          'X-Sentry-Auth': utils.getAuthHeader(timestamp, self.dsn.public_key, self.dsn.private_key),
+          'Content-Type': 'application/octet-stream',
+          'Content-Length': message.length
+        };
 
     self.transport.send(self, message, headers, ident);
   });
@@ -161,7 +161,7 @@ proto.captureException = function captureError(err, kwargs, cb) {
   } else {
     kwargs = kwargs || {};
   }
-  parsers.parseError(err, kwargs, function(kw) {
+  parsers.parseError(err, kwargs, function (kw) {
     var result = self.process(kw);
     cb && cb(result);
   });
@@ -230,7 +230,7 @@ module.exports.patchGlobal = function patchGlobal(client, cb) {
   !(client instanceof Client) && (client = new Client());
 
   var called = false;
-  process.on('uncaughtException', function(err) {
+  process.on('uncaughtException', function (err) {
     if (cb) { // bind event listeners only if a callback was supplied
       var onLogged = function onLogged() {
         called = false;
@@ -254,8 +254,8 @@ module.exports.patchGlobal = function patchGlobal(client, cb) {
 
     called = true;
 
-    client.captureError(err, function(result) {
-      node_util.log('uncaughtException: ' + client.getIdent(result));
+    return client.captureError(err, function (result) {
+      nodeUtil.log('uncaughtException: ' + client.getIdent(result));
     });
   });
 };

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -4,22 +4,22 @@ var raven = require('../client');
 var parsers = require('../parsers');
 
 // Legacy support
-var connectMiddleware = function(client) {
+var connectMiddleware = function (client) {
   return connectMiddleware.errorHandler(client);
 };
 
 // Error handler. This should be the last item listed in middleware, but
 // before any other error handlers.
-connectMiddleware.errorHandler = function(client) {
+connectMiddleware.errorHandler = function (client) {
   client = client instanceof raven.Client ? client : new raven.Client(client);
-  return function(err, req, res, next) {
+  return function (err, req, res, next) {
     var status = err.status || err.statusCode || err.status_code || 500;
 
     // skip anything not marked as an internal server error
     if (status < 500) return next(err);
 
     var kwargs = parsers.parseRequest(req);
-    client.captureError(err, kwargs, function(result) {
+    return client.captureError(err, kwargs, function (result) {
       res.sentry = client.getIdent(result);
       next(err, req, res);
     });
@@ -28,9 +28,9 @@ connectMiddleware.errorHandler = function(client) {
 
 // Ensures asynchronous exceptions are routed to the errorHandler. This
 // should be the **first** item listed in middleware.
-connectMiddleware.requestHandler = function(client) {
+connectMiddleware.requestHandler = function (client) {
   var domain = require('domain');
-  return function(req, res, next) {
+  return function (req, res, next) {
     var reqDomain = domain.create();
     reqDomain.on('error', next);
     return reqDomain.run(next);

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -14,7 +14,7 @@ module.exports.parseText = function parseText(message, kwargs) {
 };
 
 module.exports.parseError = function parseError(err, kwargs, cb) {
-  utils.parseStack(err, function(frames) {
+  utils.parseStack(err, function (frames) {
     var name = err.name + '';
     if (typeof kwargs.message === 'undefined') {
       kwargs.message = name + ': ' + (err.message || '<no message>');
@@ -96,7 +96,7 @@ module.exports.parseRequest = function parseRequest(req, kwargs) {
   //   express: req.protocol
   //   koa: req.protocol
   //
-  var protocol = 'https' === req.protocol || true === req.secure || true === (req.socket || {}).encrypted ? 'https' : 'http';
+  var protocol = req.protocol === 'https' || req.secure || (req.socket || {}).encrypted ? 'https' : 'http';
 
   // url (including path and query string):
   //

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -14,7 +14,7 @@ function HTTPTransport(options) {
   this.options = options || {};
 }
 util.inherits(HTTPTransport, Transport);
-HTTPTransport.prototype.send = function(client, message, headers, ident) {
+HTTPTransport.prototype.send = function (client, message, headers, ident) {
   var options = {
     hostname: client.dsn.host,
     path: client.dsn.path + 'api/' + client.dsn.project_id + '/store/',
@@ -28,7 +28,7 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
       options[key] = this.options[key];
     }
   }
-  var req = this.transport.request(options, function(res) {
+  var req = this.transport.request(options, function (res) {
     res.setEncoding('utf8');
     if (res.statusCode >= 200 && res.statusCode < 300) {
       client.emit('logged', ident);
@@ -44,11 +44,11 @@ HTTPTransport.prototype.send = function(client, message, headers, ident) {
       client.emit('error', e);
     }
     // force the socket to drain
-    var noop = function() {};
+    var noop = function () {};
     res.on('data', noop);
     res.on('end', noop);
   });
-  req.on('error', function(e) {
+  req.on('error', function (e) {
     client.emit('error', e);
   });
   req.end(message);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,12 +13,12 @@ var protocolMap = {
   https: 443
 };
 
-module.exports.getAuthHeader = function getAuthHeader(timestamp, api_key, api_secret) {
+module.exports.getAuthHeader = function getAuthHeader(timestamp, apiKey, apiSecret) {
   var header = ['Sentry sentry_version=5'];
   header.push('sentry_timestamp=' + timestamp);
   header.push('sentry_client=raven-node/' + raven.version);
-  header.push('sentry_key=' + api_key);
-  header.push('sentry_secret=' + api_secret);
+  header.push('sentry_key=' + apiKey);
+  header.push('sentry_secret=' + apiSecret);
   return header.join(', ');
 };
 
@@ -29,12 +29,12 @@ module.exports.parseDSN = function parseDSN(dsn) {
   }
   try {
     var parsed = url.parse(dsn),
-      response = {
-        protocol: parsed.protocol.slice(0, -1),
-        public_key: parsed.auth.split(':')[0],
-        private_key: parsed.auth.split(':')[1],
-        host: parsed.host.split(':')[0]
-      };
+        response = {
+          protocol: parsed.protocol.slice(0, -1),
+          public_key: parsed.auth.split(':')[0],
+          private_key: parsed.auth.split(':')[1],
+          host: parsed.host.split(':')[0]
+        };
 
     if (~response.protocol.indexOf('+')) {
       response.protocol = response.protocol.split('+')[1];
@@ -55,18 +55,18 @@ module.exports.parseDSN = function parseDSN(dsn) {
 };
 
 module.exports.getCulprit = function getCulprit(frame) {
-  if (frame.module || frame.function)
+  if (frame.module || frame.function) {
     return (frame.module || '?') + ' at ' + (frame.function || '?');
+  }
   return '<unknown>';
 };
 
-var module_cache;
+var moduleCache;
 module.exports.getModules = function getModules() {
-  if (module_cache) {
-    return module_cache;
+  if (!moduleCache) {
+    moduleCache = lsmod();
   }
-
-  return module_cache = lsmod();
+  return moduleCache;
 };
 
 
@@ -84,10 +84,10 @@ function getFunction(line) {
   }
 }
 
-var main_module = (require.main && path.dirname(require.main.filename) || process.cwd()) + '/';
+var mainModule = (require.main && path.dirname(require.main.filename) || process.cwd()) + '/';
 
 function getModule(filename, base) {
-  if (!base) base = main_module;
+  if (!base) base = mainModule;
 
   // It's specifically a module
   var file = path.basename(filename, '.js');
@@ -104,14 +104,14 @@ function getModule(filename, base) {
     var module = filename.substr(base.length).replace(/\//g, '.');
     if (module) module += ':';
     module += file;
-    return module
+    return module;
   }
   return file;
 }
 
 function parseStack(err, cb) {
   var frames = [],
-    cache = {}
+      cache = {};
 
   if (!err) {
     return cb(frames);
@@ -130,15 +130,13 @@ function parseStack(err, cb) {
   // Sentry requires the stack trace to be from oldest to newest
   stack.reverse();
 
-  stack.forEach(function(line, index) {
+  return stack.forEach(function (line, index) {
     var frame = {
-        filename: line.getFileName() || '',
-        lineno: line.getLineNumber(),
-        'function': getFunction(line),
-      },
-      isInternal = line.isNative() ||
-      frame.filename[0] !== '/' &&
-      frame.filename[0] !== '.';
+          filename: line.getFileName() || '',
+          lineno: line.getLineNumber(),
+          'function': getFunction(line),
+        },
+        isInternal = line.isNative() || frame.filename[0] !== '/' && frame.filename[0] !== '.';
 
     // in_app is all that's not an internal Node function or a module within node_modules
     frame.in_app = !isInternal && !~frame.filename.indexOf('node_modules/');
@@ -159,7 +157,7 @@ function parseStack(err, cb) {
       return;
     }
 
-    fs.readFile(frame.filename, function(_err, file) {
+    fs.readFile(frame.filename, function (_err, file) {
       if (!_err) {
         file = file.toString().split('\n');
         cache[frame.filename] = file;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "coffee-script": "~1.10.0",
     "connect": "*",
-    "eslint": "1.10.3",
+    "eslint": "2.13.1",
     "express": "*",
     "glob": "~3.1.13",
     "istanbul": "^0.4.3",

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -1,16 +1,16 @@
-/*eslint no-shadow:0*/
+/* eslint no-shadow:0, consistent-return:0, no-console:0 */
 'use strict';
 
 var raven = require('../'),
-  nock = require('nock'),
-  zlib = require('zlib');
+    nock = require('nock'),
+    zlib = require('zlib');
 
 var dsn = 'https://public:private@app.getsentry.com/269';
 
 var _oldConsoleWarn = console.warn;
 
 function mockConsoleWarn() {
-  console.warn = function() {
+  console.warn = function () {
     console.warn._called = true;
   };
   console.warn._called = false;
@@ -20,24 +20,24 @@ function restoreConsoleWarn() {
   console.warn = _oldConsoleWarn;
 }
 
-describe('raven.version', function() {
-  it('should be valid', function() {
+describe('raven.version', function () {
+  it('should be valid', function () {
     raven.version.should.match(/^\d+\.\d+\.\d+(-\w+)?$/);
   });
 
-  it('should match package.json', function() {
+  it('should match package.json', function () {
     var version = require('../package.json').version;
     raven.version.should.equal(version);
   });
 });
 
-describe('raven.Client', function() {
+describe('raven.Client', function () {
   var client;
-  beforeEach(function() {
+  beforeEach(function () {
     client = new raven.Client(dsn);
   });
 
-  it('should parse the DSN with options', function() {
+  it('should parse the DSN with options', function () {
     var expected = {
       protocol: 'https',
       public_key: 'public',
@@ -54,7 +54,7 @@ describe('raven.Client', function() {
     client.name.should.equal('YAY!');
   });
 
-  it('should pull SENTRY_DSN from environment', function() {
+  it('should pull SENTRY_DSN from environment', function () {
     var expected = {
       protocol: 'https',
       public_key: 'abc',
@@ -70,7 +70,7 @@ describe('raven.Client', function() {
     delete process.env.SENTRY_DSN; // gotta clean up so it doesn't leak into other tests
   });
 
-  it('should pull SENTRY_DSN from environment when passing options', function() {
+  it('should pull SENTRY_DSN from environment when passing options', function () {
     var expected = {
       protocol: 'https',
       public_key: 'abc',
@@ -89,7 +89,7 @@ describe('raven.Client', function() {
     delete process.env.SENTRY_DSN; // gotta clean up so it doesn't leak into other tests
   });
 
-  it('should be disabled when no DSN specified', function() {
+  it('should be disabled when no DSN specified', function () {
     mockConsoleWarn();
     var client = new raven.Client();
     client._enabled.should.eql(false);
@@ -97,14 +97,14 @@ describe('raven.Client', function() {
     restoreConsoleWarn();
   });
 
-  it('should pull SENTRY_NAME from environment', function() {
+  it('should pull SENTRY_NAME from environment', function () {
     process.env.SENTRY_NAME = 'new_name';
     var client = new raven.Client(dsn);
     client.name.should.eql('new_name');
     delete process.env.SENTRY_NAME;
   });
 
-  it('should be disabled for a falsey DSN', function() {
+  it('should be disabled for a falsey DSN', function () {
     mockConsoleWarn();
     var client = new raven.Client(false);
     client._enabled.should.eql(false);
@@ -112,36 +112,36 @@ describe('raven.Client', function() {
     restoreConsoleWarn();
   });
 
-  it('should pull release from options if present', function() {
+  it('should pull release from options if present', function () {
     var client = new raven.Client(dsn, {
       release: 'version1'
     });
     client.release.should.eql('version1');
   });
 
-  it('should pull SENTRY_RELEASE from environment', function() {
+  it('should pull SENTRY_RELEASE from environment', function () {
     process.env.SENTRY_RELEASE = 'version1';
     var client = new raven.Client(dsn);
     client.release.should.eql('version1');
     delete process.env.SENTRY_RELEASE;
   });
 
-  it('should pull environment from options if present', function() {
+  it('should pull environment from options if present', function () {
     var client = new raven.Client(dsn, {
       environment: 'staging'
     });
     client.environment.should.eql('staging');
   });
 
-  it('should pull SENTRY_ENVIRONMENT from environment', function() {
+  it('should pull SENTRY_ENVIRONMENT from environment', function () {
     process.env.SENTRY_ENVIRONMENT = 'staging';
     var client = new raven.Client(dsn);
     client.environment.should.eql('staging');
     delete process.env.SENTRY_ENVIRONMENT;
   });
 
-  describe('#getIdent()', function() {
-    it('should match', function() {
+  describe('#getIdent()', function () {
+    it('should match', function () {
       var result = {
         id: 'c988bf5cb7db4653825c92f6864e7206',
       };
@@ -149,34 +149,34 @@ describe('raven.Client', function() {
     });
   });
 
-  describe('#captureMessage()', function() {
-    it('should send a plain text message to Sentry server', function(done) {
+  describe('#captureMessage()', function () {
+    it('should send a plain text message to Sentry server', function (done) {
       var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')
         .reply(200, 'OK');
 
-      client.on('logged', function() {
+      client.on('logged', function () {
         scope.done();
         done();
       });
       client.captureMessage('Hey!');
     });
 
-    it('should emit error when request returns non 200', function(done) {
+    it('should emit error when request returns non 200', function (done) {
       var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')
         .reply(500, 'Oops!');
 
-      client.on('error', function() {
+      client.on('error', function () {
         scope.done();
         done();
       });
       client.captureMessage('Hey!');
     });
 
-    it('shouldn\'t shit it\'s pants when error is emitted without a listener', function() {
+    it('shouldn\'t shit it\'s pants when error is emitted without a listener', function () {
       nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')
@@ -185,7 +185,7 @@ describe('raven.Client', function() {
       client.captureMessage('Hey!');
     });
 
-    it('should attach an Error object when emitting error', function(done) {
+    it('should attach an Error object when emitting error', function (done) {
       var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')
@@ -193,7 +193,7 @@ describe('raven.Client', function() {
           'x-sentry-error': 'Oops!'
         });
 
-      client.on('error', function(e) {
+      client.on('error', function (e) {
         e.statusCode.should.eql(500);
         e.reason.should.eql('Oops!');
         e.response.should.be.ok;
@@ -205,21 +205,21 @@ describe('raven.Client', function() {
     });
   });
 
-  describe('#captureError()', function() {
-    it('should send an Error to Sentry server', function(done) {
+  describe('#captureError()', function () {
+    it('should send an Error to Sentry server', function (done) {
       var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')
         .reply(200, 'OK');
 
-      client.on('logged', function() {
+      client.on('logged', function () {
         scope.done();
         done();
       });
       client.captureError(new Error('wtf?'));
     });
 
-    it('should send a plain text "error" with a synthesized stack', function(done) {
+    it('should send a plain text "error" with a synthesized stack', function (done) {
       var old = client.send;
       client.send = function mockSend(kwargs) {
         client.send = old;
@@ -233,7 +233,7 @@ describe('raven.Client', function() {
       client.captureError('wtf?');
     });
 
-    it('should send an Error to Sentry server on another port', function(done) {
+    it('should send an Error to Sentry server on another port', function (done) {
       var scope = nock('https://app.getsentry.com:8443')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')
@@ -241,14 +241,14 @@ describe('raven.Client', function() {
 
       var dsn = 'https://public:private@app.getsentry.com:8443/269';
       var client = new raven.Client(dsn);
-      client.on('logged', function() {
+      client.on('logged', function () {
         scope.done();
         done();
       });
       client.captureError(new Error('wtf?'));
     });
 
-    it('shouldn\'t choke on circular references', function(done) {
+    it('shouldn\'t choke on circular references', function (done) {
       // See: https://github.com/mattrobenolt/raven-node/pull/46
       var old = zlib.deflate;
       zlib.deflate = function mockSend(skwargs) {
@@ -272,14 +272,14 @@ describe('raven.Client', function() {
     });
   });
 
-  describe('#patchGlobal()', function() {
-    beforeEach(function() {
+  describe('#patchGlobal()', function () {
+    beforeEach(function () {
       // remove existing uncaughtException handlers
       this.uncaughtBefore = process.listeners('uncaughtException');
       process.removeAllListeners('uncaughtException');
     });
 
-    afterEach(function() {
+    afterEach(function () {
       var uncaughtBefore = this.uncaughtBefore;
       // restore things to how they were
       for (var i = 0; i < uncaughtBefore.length; i++) {
@@ -287,7 +287,7 @@ describe('raven.Client', function() {
       }
     });
 
-    it('should add itself to the uncaughtException event list', function() {
+    it('should add itself to the uncaughtException event list', function () {
       var listeners = process.listeners('uncaughtException');
       listeners.length.should.equal(0);
 
@@ -297,13 +297,13 @@ describe('raven.Client', function() {
       listeners.length.should.equal(1);
     });
 
-    it('should send an uncaughtException to Sentry server', function(done) {
+    it('should send an uncaughtException to Sentry server', function (done) {
       var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')
         .reply(200, 'OK');
 
-      client.on('logged', function() {
+      client.on('logged', function () {
         scope.done();
         done();
       });
@@ -311,27 +311,27 @@ describe('raven.Client', function() {
       process.emit('uncaughtException', new Error('derp'));
     });
 
-    it('should trigger a callback after an uncaughtException', function(done) {
+    it('should trigger a callback after an uncaughtException', function (done) {
       var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')
         .reply(200, 'OK');
 
-      client.patchGlobal(function() {
+      client.patchGlobal(function () {
         scope.done();
         done();
       });
       process.emit('uncaughtException', new Error('derp'));
     });
 
-    it('should not enter in recursion when an error is thrown on client request', function(done) {
+    it('should not enter in recursion when an error is thrown on client request', function (done) {
       var transportBefore = client.transport.send;
 
-      client.transport.send = function() {
+      client.transport.send = function () {
         throw new Error('foo');
       };
 
-      client.patchGlobal(function(success, err) {
+      client.patchGlobal(function (success, err) {
         success.should.eql(false);
         err.should.be.instanceOf(Error);
         err.message.should.equal('foo');
@@ -346,14 +346,14 @@ describe('raven.Client', function() {
     });
   });
 
-  describe('#process()', function() {
-    it('should respect dataCallback', function(done) {
-      client = new raven.Client(dsn);
+  describe('#process()', function () {
+    it('should respect dataCallback', function (done) {
+      var client = new raven.Client(dsn);
       var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')
-        .reply(200, function(uri, body) {
-          zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
+        .reply(200, function (uri, body) {
+          zlib.inflate(new Buffer(body, 'base64'), function (err, dec) {
             if (err) return done(err);
             var msg = JSON.parse(dec.toString());
             var extra = msg.extra;
@@ -364,8 +364,8 @@ describe('raven.Client', function() {
           return 'OK';
         });
 
-      var client = new raven.Client(dsn, {
-        dataCallback: function(data) {
+      client = new raven.Client(dsn, {
+        dataCallback: function (data) {
           delete data.extra.foo;
           return data;
         }
@@ -378,7 +378,7 @@ describe('raven.Client', function() {
         }
       });
 
-      client.on('logged', function() {
+      client.on('logged', function () {
         scope.done();
       });
     });
@@ -390,7 +390,7 @@ describe('raven.Client', function() {
       client.send = function (kwargs) {
         kwargs.environment.should.equal('staging');
       };
-      client.process({message: 'test'});
+      client.process({ message: 'test' });
 
       client.send = function (kwargs) {
         kwargs.environment.should.equal('production');
@@ -403,7 +403,7 @@ describe('raven.Client', function() {
     });
   });
 
-  it('should use a custom transport', function() {
+  it('should use a custom transport', function () {
     var expected = {
       protocol: 'https',
       public_key: 'public',
@@ -421,7 +421,7 @@ describe('raven.Client', function() {
     client.transport.should.equal('some_heka_instance');
   });
 
-  it('should use a DSN subpath when sending requests', function(done) {
+  it('should use a DSN subpath when sending requests', function (done) {
     var dsn = 'https://public:private@app.getsentry.com/some/path/269';
     var client = new raven.Client(dsn);
 
@@ -430,19 +430,19 @@ describe('raven.Client', function() {
       .post('/some/path/api/269/store/', '*')
       .reply(200, 'OK');
 
-    client.on('logged', function() {
+    client.on('logged', function () {
       scope.done();
       done();
     });
     client.captureMessage('Hey!');
   });
 
-  it('should capture module information', function(done) {
+  it('should capture module information', function (done) {
     var scope = nock('https://app.getsentry.com')
       .filteringRequestBody(/.*/, '*')
       .post('/api/269/store/', '*')
-      .reply(200, function(uri, body) {
-        zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
+      .reply(200, function (uri, body) {
+        zlib.inflate(new Buffer(body, 'base64'), function (err, dec) {
           if (err) return done(err);
           var msg = JSON.parse(dec.toString());
           var modules = msg.modules;
@@ -454,13 +454,13 @@ describe('raven.Client', function() {
         return 'OK';
       });
 
-    client.on('logged', function() {
+    client.on('logged', function () {
       scope.done();
     });
     client.captureError(new Error('wtf?'));
   });
 
-  it('should capture extra data', function(done) {
+  it('should capture extra data', function (done) {
     client = new raven.Client(dsn, {
       extra: {
         globalContextKey: 'globalContextValue'
@@ -470,8 +470,8 @@ describe('raven.Client', function() {
     var scope = nock('https://app.getsentry.com')
       .filteringRequestBody(/.*/, '*')
       .post('/api/269/store/', '*')
-      .reply(200, function(uri, body) {
-        zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
+      .reply(200, function (uri, body) {
+        zlib.inflate(new Buffer(body, 'base64'), function (err, dec) {
           if (err) return done(err);
           var msg = JSON.parse(dec.toString());
           var extra = msg.extra;
@@ -479,14 +479,14 @@ describe('raven.Client', function() {
           extra.should.have.property('key');
           extra.key.should.equal('value');
           extra.should.have.property('globalContextKey');
-          extra.globalContextKey.should.equal('globalContextValue')
+          extra.globalContextKey.should.equal('globalContextValue');
 
           done();
         });
         return 'OK';
       });
 
-    client.on('logged', function() {
+    client.on('logged', function () {
       scope.done();
     });
     client.process({
@@ -497,7 +497,7 @@ describe('raven.Client', function() {
     });
   });
 
-  it('should capture tags', function(done) {
+  it('should capture tags', function (done) {
     client = new raven.Client(dsn, {
       tags: {
         globalContextKey: 'globalContextValue'
@@ -506,8 +506,8 @@ describe('raven.Client', function() {
     var scope = nock('https://app.getsentry.com')
       .filteringRequestBody(/.*/, '*')
       .post('/api/269/store/', '*')
-      .reply(200, function(uri, body) {
-        zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
+      .reply(200, function (uri, body) {
+        zlib.inflate(new Buffer(body, 'base64'), function (err, dec) {
           if (err) return done(err);
           var msg = JSON.parse(dec.toString());
           var tags = msg.tags;
@@ -515,14 +515,14 @@ describe('raven.Client', function() {
           tags.should.have.property('key');
           tags.key.should.equal('value');
           tags.should.have.property('globalContextKey');
-          tags.globalContextKey.should.equal('globalContextValue')
+          tags.globalContextKey.should.equal('globalContextValue');
 
           done();
         });
         return 'OK';
       });
 
-    client.on('logged', function() {
+    client.on('logged', function () {
       scope.done();
     });
     client.process({
@@ -533,12 +533,12 @@ describe('raven.Client', function() {
     });
   });
 
-  it('should capture fingerprint', function(done) {
+  it('should capture fingerprint', function (done) {
     var scope = nock('https://app.getsentry.com')
       .filteringRequestBody(/.*/, '*')
       .post('/api/269/store/', '*')
-      .reply(200, function(uri, body) {
-        zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
+      .reply(200, function (uri, body) {
+        zlib.inflate(new Buffer(body, 'base64'), function (err, dec) {
           if (err) return done(err);
           var msg = JSON.parse(dec.toString());
 
@@ -550,7 +550,7 @@ describe('raven.Client', function() {
         return 'OK';
       });
 
-    client.on('logged', function() {
+    client.on('logged', function () {
       scope.done();
     });
     client.process({
@@ -559,12 +559,12 @@ describe('raven.Client', function() {
     });
   });
 
-  it('should capture user', function(done) {
+  it('should capture user', function (done) {
     var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')
-        .reply(200, function(uri, body) {
-          zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
+        .reply(200, function (uri, body) {
+          zlib.inflate(new Buffer(body, 'base64'), function (err, dec) {
             if (err) return done(err);
             var msg = JSON.parse(dec.toString());
 
@@ -585,7 +585,7 @@ describe('raven.Client', function() {
       id: '123'
     });
 
-    client.on('logged', function() {
+    client.on('logged', function () {
       scope.done();
     });
     client.process({
@@ -593,12 +593,12 @@ describe('raven.Client', function() {
     });
   });
 
-  it('should capture release', function(done) {
+  it('should capture release', function (done) {
     var scope = nock('https://app.getsentry.com')
       .filteringRequestBody(/.*/, '*')
       .post('/api/269/store/', '*')
-      .reply(200, function(uri, body) {
-        zlib.inflate(new Buffer(body, 'base64'), function(err, dec) {
+      .reply(200, function (uri, body) {
+        zlib.inflate(new Buffer(body, 'base64'), function (err, dec) {
           if (err) return done(err);
           var msg = JSON.parse(dec.toString());
 
@@ -612,7 +612,7 @@ describe('raven.Client', function() {
     var client = new raven.Client(dsn, {
       release: 'version1'
     });
-    client.on('logged', function() {
+    client.on('logged', function () {
       scope.done();
     });
     client.process({
@@ -620,7 +620,7 @@ describe('raven.Client', function() {
     });
   });
 
-  describe('#setUserContext()', function() {
+  describe('#setUserContext()', function () {
     it('should add the user object to the globalContext', function () {
       var user = {
         email: 'matt@example.com', // <-- my fave user
@@ -633,7 +633,7 @@ describe('raven.Client', function() {
     });
   });
 
-  describe('#setExtraContext()', function() {
+  describe('#setExtraContext()', function () {
     it('should merge the extra data object into the globalContext', function () {
       // when no pre-existing context
       client.setExtraContext({
@@ -651,7 +651,7 @@ describe('raven.Client', function() {
     });
   });
 
-  describe('#setTagsContext()', function() {
+  describe('#setTagsContext()', function () {
     it('should merge the extra data object into the globalContext', function () {
       // when no pre-existing context
       client.setTagsContext({

--- a/test/raven.parsers.js
+++ b/test/raven.parsers.js
@@ -5,14 +5,14 @@ var raven = require('../');
 
 raven.parsers = require('../lib/parsers');
 
-describe('raven.parsers', function() {
-  describe('#parseText()', function() {
-    it('should parse some text without kwargs', function() {
+describe('raven.parsers', function () {
+  describe('#parseText()', function () {
+    it('should parse some text without kwargs', function () {
       var parsed = raven.parsers.parseText('Howdy');
       parsed.message.should.equal('Howdy');
     });
 
-    it('should parse some text with kwargs', function() {
+    it('should parse some text with kwargs', function () {
       var parsed = raven.parsers.parseText('Howdy', {
         'foo': 'bar'
       });
@@ -21,8 +21,8 @@ describe('raven.parsers', function() {
     });
   });
 
-  describe('#parseQuery()', function() {
-    it('should parse a query', function() {
+  describe('#parseQuery()', function () {
+    it('should parse a query', function () {
       var query = 'SELECT * FROM `something`';
       var engine = 'mysql';
       var parsed = raven.parsers.parseQuery(query, engine);
@@ -33,8 +33,8 @@ describe('raven.parsers', function() {
     });
   });
 
-  describe('#parseRequest()', function() {
-    it('should parse a request object', function() {
+  describe('#parseRequest()', function () {
+    it('should parse a request object', function () {
       var mockReq = {
         method: 'GET',
         url: '/some/path?key=value',
@@ -56,8 +56,8 @@ describe('raven.parsers', function() {
       parsed.user.ip_address.should.equal('127.0.0.1');
     });
 
-    describe('`headers` detection', function() {
-      it('should detect headers via `req.headers`', function() {
+    describe('`headers` detection', function () {
+      it('should detect headers via `req.headers`', function () {
         var mockReq = {
           method: 'GET',
           hostname: 'mattrobenolt.com',
@@ -74,7 +74,7 @@ describe('raven.parsers', function() {
         });
       });
 
-      it('should detect headers via `req.header`', function() {
+      it('should detect headers via `req.header`', function () {
         var mockReq = {
           method: 'GET',
           hostname: 'mattrobenolt.com',
@@ -92,8 +92,8 @@ describe('raven.parsers', function() {
       });
     });
 
-    describe('`method` detection', function() {
-      it('should detect method via `req.method`', function() {
+    describe('`method` detection', function () {
+      it('should detect method via `req.method`', function () {
         var mockReq = {
           method: 'GET',
           hostname: 'mattrobenolt.com',
@@ -106,8 +106,8 @@ describe('raven.parsers', function() {
       });
     });
 
-    describe('`host` detection', function() {
-      it('should detect host via `req.hostname`', function() {
+    describe('`host` detection', function () {
+      it('should detect host via `req.hostname`', function () {
         var mockReq = {
           method: 'GET',
           hostname: 'mattrobenolt.com',
@@ -119,7 +119,7 @@ describe('raven.parsers', function() {
         parsed.request.url.should.equal('http://mattrobenolt.com/some/path?key=value');
       });
 
-      it('should detect host via deprecated `req.host`', function() {
+      it('should detect host via deprecated `req.host`', function () {
         var mockReq = {
           method: 'GET',
           host: 'mattrobenolt.com',
@@ -131,7 +131,7 @@ describe('raven.parsers', function() {
         parsed.request.url.should.equal('http://mattrobenolt.com/some/path?key=value');
       });
 
-      it('should detect host via `req.header.host`', function() {
+      it('should detect host via `req.header.host`', function () {
         var mockReq = {
           method: 'GET',
           header: {
@@ -145,7 +145,7 @@ describe('raven.parsers', function() {
         parsed.request.url.should.equal('http://mattrobenolt.com/some/path?key=value');
       });
 
-      it('should detect host via `req.headers.host`', function() {
+      it('should detect host via `req.headers.host`', function () {
         var mockReq = {
           method: 'GET',
           headers: {
@@ -159,7 +159,7 @@ describe('raven.parsers', function() {
         parsed.request.url.should.equal('http://mattrobenolt.com/some/path?key=value');
       });
 
-      it('should fallback to <no host> if host is not available', function() {
+      it('should fallback to <no host> if host is not available', function () {
         var mockReq = {
           method: 'GET',
           url: '/some/path?key=value'
@@ -171,8 +171,8 @@ describe('raven.parsers', function() {
       });
     });
 
-    describe('`protocol` detection', function() {
-      it('should detect protocol via `req.protocol`', function() {
+    describe('`protocol` detection', function () {
+      it('should detect protocol via `req.protocol`', function () {
         var mockReq = {
           method: 'GET',
           url: '/some/path?key=value',
@@ -190,7 +190,7 @@ describe('raven.parsers', function() {
         parsed.request.url.should.equal('https://mattrobenolt.com/some/path?key=value');
       });
 
-      it('should detect protocol via `req.secure`', function() {
+      it('should detect protocol via `req.secure`', function () {
         var mockReq = {
           method: 'GET',
           url: '/some/path?key=value',
@@ -208,7 +208,7 @@ describe('raven.parsers', function() {
         parsed.request.url.should.equal('https://mattrobenolt.com/some/path?key=value');
       });
 
-      it('should detect protocol via `req.socket.encrypted`', function() {
+      it('should detect protocol via `req.socket.encrypted`', function () {
         var mockReq = {
           method: 'GET',
           url: '/some/path?key=value',
@@ -226,8 +226,8 @@ describe('raven.parsers', function() {
       });
     });
 
-    describe('`cookie` detection', function() {
-      it('should parse `req.headers.cookie`', function() {
+    describe('`cookie` detection', function () {
+      it('should parse `req.headers.cookie`', function () {
         var mockReq = {
           method: 'GET',
           url: '/some/path?key=value',
@@ -243,7 +243,7 @@ describe('raven.parsers', function() {
         });
       });
 
-      it('should parse `req.header.cookie`', function() {
+      it('should parse `req.header.cookie`', function () {
         var mockReq = {
           method: 'GET',
           url: '/some/path?key=value',
@@ -261,8 +261,8 @@ describe('raven.parsers', function() {
 
     });
 
-    describe('`query` detection', function() {
-      it('should detect query via `req.query`', function() {
+    describe('`query` detection', function () {
+      it('should detect query via `req.query`', function () {
         var mockReq = {
           method: 'GET',
           hostname: 'mattrobenolt.com',
@@ -279,7 +279,7 @@ describe('raven.parsers', function() {
         });
       });
 
-      it('should detect query via `req.url`', function() {
+      it('should detect query via `req.url`', function () {
         var mockReq = {
           method: 'GET',
           hostname: 'mattrobenolt.com',
@@ -294,8 +294,8 @@ describe('raven.parsers', function() {
       });
     });
 
-    describe('`ip` detection', function() {
-      it('should detect ip via `req.ip`', function() {
+    describe('`ip` detection', function () {
+      it('should detect ip via `req.ip`', function () {
         var mockReq = {
           method: 'GET',
           url: '/some/path?key=value',
@@ -310,7 +310,7 @@ describe('raven.parsers', function() {
         parsed.user.ip_address.should.equal('127.0.0.1');
       });
 
-      it('should detect ip via `req.connection.remoteAddress`', function() {
+      it('should detect ip via `req.connection.remoteAddress`', function () {
         var mockReq = {
           method: 'GET',
           url: '/some/path?key=value',
@@ -328,8 +328,8 @@ describe('raven.parsers', function() {
       });
     });
 
-    describe('`url` detection', function() {
-      it('should detect url via `req.originalUrl`', function() {
+    describe('`url` detection', function () {
+      it('should detect url via `req.originalUrl`', function () {
         var mockReq = {
           method: 'GET',
           protocol: 'https',
@@ -342,7 +342,7 @@ describe('raven.parsers', function() {
         parsed.request.url.should.equal('https://mattrobenolt.com/some/path?key=value');
       });
 
-      it('should detect url via `req.url`', function() {
+      it('should detect url via `req.url`', function () {
         var mockReq = {
           method: 'GET',
           protocol: 'https',
@@ -356,8 +356,8 @@ describe('raven.parsers', function() {
       });
     });
 
-    describe('`body` detection', function() {
-      it('should detect body via `req.body`', function() {
+    describe('`body` detection', function () {
+      it('should detect body via `req.body`', function () {
         var mockReq = {
           method: 'GET',
           hostname: 'mattrobenolt.com',
@@ -370,7 +370,7 @@ describe('raven.parsers', function() {
         parsed.request.data.should.equal('foo=bar');
       });
 
-      it('should fallback to <unavailable> if body is not available', function() {
+      it('should fallback to <unavailable> if body is not available', function () {
         var mockReq = {
           method: 'POST',
           hostname: 'mattrobenolt.com',
@@ -382,7 +382,7 @@ describe('raven.parsers', function() {
         parsed.request.data.should.equal('<unavailable>');
       });
 
-      it('should not fallback to <unavailable> if GET', function() {
+      it('should not fallback to <unavailable> if GET', function () {
         var mockReq = {
           method: 'GET',
           hostname: 'mattrobenolt.com',
@@ -394,7 +394,7 @@ describe('raven.parsers', function() {
         (typeof parsed.request.data === 'undefined').should.be.ok;
       });
 
-      it('should make sure that body is a string', function() {
+      it('should make sure that body is a string', function () {
         var mockReq = {
           method: 'POST',
           hostname: 'mattrobenolt.com',
@@ -405,7 +405,7 @@ describe('raven.parsers', function() {
         };
 
         var parsed = raven.parsers.parseRequest(mockReq);
-        parsed.request.data.should.equal('{\"foo\":true}');
+        parsed.request.data.should.equal('{"foo":true}');
       });
     });
 
@@ -465,9 +465,9 @@ describe('raven.parsers', function() {
     });
   });
 
-  describe('#parseError()', function() {
-    it('should parse plain Error object', function(done) {
-      raven.parsers.parseError(new Error(), {}, function(parsed) {
+  describe('#parseError()', function () {
+    it('should parse plain Error object', function (done) {
+      raven.parsers.parseError(new Error(), {}, function (parsed) {
         parsed.message.should.equal('Error: <no message>');
         parsed.should.have.property('exception');
         parsed.exception[0].type.should.equal('Error');
@@ -477,8 +477,8 @@ describe('raven.parsers', function() {
       });
     });
 
-    it('should parse Error with message', function(done) {
-      raven.parsers.parseError(new Error('Crap'), {}, function(parsed) {
+    it('should parse Error with message', function (done) {
+      raven.parsers.parseError(new Error('Crap'), {}, function (parsed) {
         parsed.message.should.equal('Error: Crap');
         parsed.should.have.property('exception');
         parsed.exception[0].type.should.equal('Error');
@@ -488,8 +488,8 @@ describe('raven.parsers', function() {
       });
     });
 
-    it('should parse TypeError with message', function(done) {
-      raven.parsers.parseError(new TypeError('Crap'), {}, function(parsed) {
+    it('should parse TypeError with message', function (done) {
+      raven.parsers.parseError(new TypeError('Crap'), {}, function (parsed) {
         parsed.message.should.equal('TypeError: Crap');
         parsed.should.have.property('exception');
         parsed.exception[0].type.should.equal('TypeError');
@@ -499,10 +499,10 @@ describe('raven.parsers', function() {
       });
     });
 
-    it('should parse Error with non-string type', function(done) {
+    it('should parse Error with non-string type', function (done) {
       var err = new Error();
       err.name = {};
-      raven.parsers.parseError(err, {}, function(parsed) {
+      raven.parsers.parseError(err, {}, function (parsed) {
         parsed.message.should.equal('[object Object]: <no message>');
         parsed.should.have.property('exception');
         parsed.exception[0].type.should.equal('[object Object]');
@@ -512,11 +512,11 @@ describe('raven.parsers', function() {
       });
     });
 
-    it('should parse thrown Error', function(done) {
+    it('should parse thrown Error', function (done) {
       try {
         throw new Error('Derp');
       } catch (e) {
-        raven.parsers.parseError(e, {}, function(parsed) {
+        raven.parsers.parseError(e, {}, function (parsed) {
           parsed.message.should.equal('Error: Derp');
           parsed.should.have.property('exception');
           parsed.exception[0].type.should.equal('Error');
@@ -527,37 +527,37 @@ describe('raven.parsers', function() {
       }
     });
 
-    it('should allow specifying a custom `culprit`', function(done) {
+    it('should allow specifying a custom `culprit`', function (done) {
       try {
         throw new Error('Foobar');
       } catch (e) {
         raven.parsers.parseError(e, {
           culprit: 'foobar'
-        }, function(parsed) {
+        }, function (parsed) {
           parsed.culprit.should.equal('foobar');
           done();
         });
       }
     });
 
-    it('should have a string stack after parsing', function(done) {
+    it('should have a string stack after parsing', function (done) {
       try {
         throw new Error('Derp');
       } catch (e) {
-        raven.parsers.parseError(e, {}, function(parsed) {
+        raven.parsers.parseError(e, {}, function (parsed) {
           e.stack.should.be.a.String;
           done();
         });
       }
     });
 
-    it('should parse caught real error', function(done) {
-      /*eslint new-cap:0*/
+    it('should parse caught real error', function (done) {
+      /* eslint new-cap:0 */
       try {
         var o = {};
         o['...'].Derp();
       } catch (e) {
-        raven.parsers.parseError(e, {}, function(parsed) {
+        raven.parsers.parseError(e, {}, function (parsed) {
           parsed.message.should.containEql('TypeError');
           parsed.message.should.containEql('Derp');
           parsed.should.have.property('exception');
@@ -569,11 +569,11 @@ describe('raven.parsers', function() {
       }
     });
 
-    it('should parse an error with additional information', function(done) {
+    it('should parse an error with additional information', function (done) {
       try {
         assert.strictEqual(1, 2);
       } catch (e) {
-        raven.parsers.parseError(e, {}, function(parsed) {
+        raven.parsers.parseError(e, {}, function (parsed) {
           parsed.should.have.property('exception');
           parsed.exception[0].stacktrace.should.have.property('frames');
           parsed.should.have.property('extra');

--- a/test/raven.utils.js
+++ b/test/raven.utils.js
@@ -1,10 +1,11 @@
+/* eslint max-len:0 */
 'use strict';
 
 var raven = require('../');
 
-describe('raven.utils', function() {
-  describe('#parseDSN()', function() {
-    it('should parse hosted Sentry DSN without path', function() {
+describe('raven.utils', function () {
+  describe('#parseDSN()', function () {
+    it('should parse hosted Sentry DSN without path', function () {
       var dsn = raven.utils.parseDSN('https://8769c40cf49c4cc58b51fa45d8e2d166:296768aa91084e17b5ac02d3ad5bc7e7@app.getsentry.com/269');
       var expected = {
         protocol: 'https',
@@ -18,7 +19,7 @@ describe('raven.utils', function() {
       dsn.should.eql(expected);
     });
 
-    it('should parse http not on hosted Sentry with path', function() {
+    it('should parse http not on hosted Sentry with path', function () {
       var dsn = raven.utils.parseDSN('http://8769c40cf49c4cc58b51fa45d8e2d166:296768aa91084e17b5ac02d3ad5bc7e7@mysentry.com/some/other/path/269');
       var expected = {
         protocol: 'http',
@@ -32,7 +33,7 @@ describe('raven.utils', function() {
       dsn.should.eql(expected);
     });
 
-    it('should parse DSN with non-standard port', function() {
+    it('should parse DSN with non-standard port', function () {
       var dsn = raven.utils.parseDSN('https://8769c40cf49c4cc58b51fa45d8e2d166:296768aa91084e17b5ac02d3ad5bc7e7@mysentry.com:8443/some/other/path/269');
       var expected = {
         protocol: 'https',
@@ -46,18 +47,18 @@ describe('raven.utils', function() {
       dsn.should.eql(expected);
     });
 
-    it('should return false for a falsey dns', function() {
+    it('should return false for a falsey dns', function () {
       raven.utils.parseDSN(false).should.eql(false);
       raven.utils.parseDSN('').should.eql(false);
     });
 
-    it('show throw an Error on invalid transport protocol', function() {
-      (function() {
+    it('show throw an Error on invalid transport protocol', function () {
+      (function () {
         raven.utils.parseDSN('noop://8769c40cf49c4cc58b51fa45d8e2d166:296768aa91084e17b5ac02d3ad5bc7e7@mysentry.com:1234/some/other/path/269');
       }).should.throw();
     });
 
-    it('should ignore a sub-transport protocol', function() {
+    it('should ignore a sub-transport protocol', function () {
       var dsn = raven.utils.parseDSN('gevent+https://8769c40cf49c4cc58b51fa45d8e2d166:296768aa91084e17b5ac02d3ad5bc7e7@mysentry.com:8443/some/other/path/269');
       var expected = {
         protocol: 'https',
@@ -72,25 +73,25 @@ describe('raven.utils', function() {
     });
   });
 
-  describe('#parseAuthHeader()', function() {
-    it('should parse all parameters', function() {
+  describe('#parseAuthHeader()', function () {
+    it('should parse all parameters', function () {
       var timestamp = 12345,
-        api_key = 'abc',
-        api_secret = 'xyz';
+          apiKey = 'abc',
+          apiSecret = 'xyz';
       var expected = 'Sentry sentry_version=5, sentry_timestamp=12345, sentry_client=raven-node/' + raven.version + ', sentry_key=abc, sentry_secret=xyz';
-      raven.utils.getAuthHeader(timestamp, api_key, api_secret).should.equal(expected);
+      raven.utils.getAuthHeader(timestamp, apiKey, apiSecret).should.equal(expected);
     });
   });
 
-  describe('#parseStack()', function() {
+  describe('#parseStack()', function () {
     // needs new tests with a mock callsite object
-    it('shouldnt barf on an invalid stack', function() {
+    it('shouldnt barf on an invalid stack', function () {
       var parseStack = raven.utils.parseStack;
-      var callback = function(frames) {
+      var callback = function (frames) {
         frames.length.should.equal(0);
-      }
+      };
       parseStack('lol', callback);
-      parseStack(undefined, callback);
+      parseStack(void 0, callback);
       parseStack([], callback);
       parseStack([{
         lol: 1
@@ -98,24 +99,24 @@ describe('raven.utils', function() {
     });
   });
 
-  describe('#getCulprit()', function() {
-    it('should handle empty', function() {
+  describe('#getCulprit()', function () {
+    it('should handle empty', function () {
       raven.utils.getCulprit({}).should.eql('<unknown>');
     });
 
-    it('should handle missing module', function() {
+    it('should handle missing module', function () {
       raven.utils.getCulprit({
         'function': 'foo'
       }).should.eql('? at foo');
     });
 
-    it('should handle missing function', function() {
+    it('should handle missing function', function () {
       raven.utils.getCulprit({
         module: 'foo'
       }).should.eql('foo at ?');
     });
 
-    it('should work', function() {
+    it('should work', function () {
       raven.utils.getCulprit({
         module: 'foo',
         'function': 'bar'
@@ -123,18 +124,18 @@ describe('raven.utils', function() {
     });
   });
 
-  describe('#getModule()', function() {
-    it('should identify a node_module', function() {
+  describe('#getModule()', function () {
+    it('should identify a node_module', function () {
       var filename = '/home/x/node_modules/foo/bar/baz.js';
       raven.utils.getModule(filename).should.eql('foo.bar:baz');
     });
 
-    it('should identify a main module', function() {
+    it('should identify a main module', function () {
       var filename = '/home/x/foo/bar/baz.js';
       raven.utils.getModule(filename, '/home/x/').should.eql('foo.bar:baz');
     });
 
-    it('should fallback to just filename', function() {
+    it('should fallback to just filename', function () {
       var filename = '/home/lol.js';
       raven.utils.getModule(filename).should.eql('lol');
     });


### PR DESCRIPTION
I made the eslintrc more strict and cleaned up a few minor things that that caught; it wasn't much so these code changes are pretty minor, but the PR is mostly to make sure the ESLint version situation makes sense:

We're using 2.13.1 here instead of latest 3.5.0 because ESLint 3.x dropped support for node < 4. With 3.5.0 travis would fail on 0.8-0.12, but we don't have a strong reason to need ESLint 3.x, so staying on 2.x was the easiest fix for now.

Unfortunately the Travis docs didn't have anything helpful to let us run a different test command for different node versions, so if we want to upgrade to ESLint 3.x, I think the best we could do is make the lint step figure out if it's on node < 4 and if so skip linting.

/cc @benvinegar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/205)
<!-- Reviewable:end -->
