### PR TITLE
Update and lock down dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "cookie": "0.1.0",
-    "json-stringify-safe": "^5.0.1",
+    "cookie": "0.3.1",
+    "json-stringify-safe": "5.0.1",
     "lsmod": "1.0.0",
-    "node-uuid": "~1.4.1",
-    "stack-trace": "0.0.7"
+    "node-uuid": "1.4.7",
+    "stack-trace": "0.0.9"
   },
   "devDependencies": {
     "coffee-script": "~1.10.0",


### PR DESCRIPTION
Good news: I audited each of our dependencies and they all
1) have no further dependencies
2) are pretty stable
3) are by developers I recognize
so I'm not going to worry about shrinkwrapping or anything like that as long as we have the versions pinned.

The version updates reflected here are all pretty minor and should be fully BC.
/cc @benvinegar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/206)
<!-- Reviewable:end -->
