### PR TITLE
runWithContext and friends

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -356,4 +356,6 @@ proto.install = function (cb) {
 
 proto.patchGlobal = module.exports.patchGlobal = function (cb) {
   utils.consoleAlert('patchGlobal has been deprecated and will be removed in v2.0');
+  patchGlobal(this, cb);
+  return this;
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,6 +14,8 @@ module.exports.version = require('../package.json').version;
 
 var extend = utils.extend;
 
+module.exports.disableConsoleAlerts = utils.disableConsoleAlerts;
+
 var Client = function Client(dsn, options) {
   if (arguments.length === 0) {
     // no arguments, use default from environment
@@ -38,6 +40,10 @@ var Client = function Client(dsn, options) {
   this.loggerName = options.logger || '';
   this.dataCallback = options.dataCallback;
 
+  if (!this.dsn) {
+    utils.consoleAlert('no DSN provided, error reporting disabled');
+  }
+
   if (this.dsn.protocol === 'https') {
     // In case we want to provide our own SSL certificates / keys
     this.ca = options.ca || null;
@@ -54,7 +60,9 @@ var Client = function Client(dsn, options) {
     globalContext.extra = options.extra;
   }
 
-  this.on('error', function (e) {}); // noop
+  this.on('error', function (err) {
+    utils.consoleAlert('failed to send exception to sentry: ' + err.message);
+  });
 };
 nodeUtil.inherits(Client, events.EventEmitter);
 var proto = Client.prototype;
@@ -141,7 +149,7 @@ proto.captureMessage = function captureMessage(message, kwargs, cb) {
   return result;
 };
 
-proto.captureException = function captureError(err, kwargs, cb) {
+proto.captureException = function captureException(err, kwargs, cb) {
   if (!(err instanceof Error)) {
     // This handles when someone does:
     //   throw "something awesome";
@@ -161,7 +169,11 @@ proto.captureException = function captureError(err, kwargs, cb) {
     cb && cb(result);
   });
 };
-proto.captureError = proto.captureException; // legacy alias
+
+proto.captureError = function () {
+  utils.consoleAlert('client.captureError has been deprecated and will be removed in v2.0');
+  this.captureException.apply(this, arguments);
+}
 
 proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
   if (!cb && typeof kwargs === 'function') {
@@ -211,11 +223,8 @@ proto.context = function (ctx, cb, onErr) {
  * @return {Raven}
  */
 proto.setUserContext = function setUserContext(user) {
-  if (domain.active && domain.active.sentryContext) {
-    domain.active.sentryContext.user = user;
-  } else {
-    this._globalContext.user = user;
-  }
+  utils.consoleAlert('setUserContext has been deprecated and will be removed in v2.0');
+  this._globalContext.user = user;
   return this;
 };
 
@@ -226,11 +235,8 @@ proto.setUserContext = function setUserContext(user) {
  * @return {Raven}
  */
 proto.setExtraContext = function setExtraContext(extra) {
-  if (domain.active && domain.active.sentryContext) {
-    domain.active.sentryContext.extra = extend({}, domain.active.sentryContext.extra, extra);
-  } else {
-    this._globalContext.extra = extend({}, this._globalContext.extra, extra);
-  }
+  utils.consoleAlert('setExtraContext has been deprecated and will be removed in v2.0');
+  this._globalContext.extra = extend({}, this._globalContext.extra, extra);
   return this;
 };
 
@@ -241,11 +247,8 @@ proto.setExtraContext = function setExtraContext(extra) {
  * @return {Raven}
  */
 proto.setTagsContext = function setTagsContext(tags) {
-  if (domain.active && domain.active.sentryContext) {
-    domain.active.sentryContext.tags = extend({}, domain.active.sentryContext.tags, tags);
-  } else {
-    this._globalContext.tags = extend({}, this._globalContext.tags, tags);
-  }
+  utils.consoleAlert('setTagsContext has been deprecated and will be removed in v2.0');
+  this._globalContext.tags = extend({}, this._globalContext.tags, tags);
   return this;
 };
 
@@ -291,8 +294,8 @@ module.exports.patchGlobal = function patchGlobal(client, cb) {
 
     called = true;
 
-    return client.captureError(err, function (result) {
-      nodeUtil.log('uncaughtException: ' + client.getIdent(result));
+    return client.captureException(err, function (result) {
+      utils.consoleAlert('uncaughtException: ' + client.getIdent(result));
     });
   });
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -61,6 +61,10 @@ var proto = Client.prototype;
 
 module.exports.Client = Client;
 
+module.exports.config = function (dsn, options) {
+  return new Client(dsn, options);
+};
+
 proto.getIdent =
   proto.get_ident = function getIdent(result) {
     return result.id;
@@ -176,7 +180,7 @@ proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
  * We could consider getting rid of it and just duplicating the domain
  * instantiation etc logic in the requestHandler middleware
  */
-proto.runWithContext = function (ctx, cb, onErr) {
+proto.context = function (ctx, cb, onErr) {
   if (!cb && typeof ctx === 'function') {
     cb = ctx;
     ctx = {};
@@ -208,7 +212,9 @@ proto.runWithContext = function (ctx, cb, onErr) {
  */
 proto.setUserContext = function setUserContext(user) {
   if (domain.active && domain.active.sentryContext) {
-    domain.active.sentryContext.user = extend({}, domain.active.sentryContext.user, user);
+    domain.active.sentryContext.user = user;
+  } else {
+    this._globalContext.user = user;
   }
   return this;
 };
@@ -222,6 +228,8 @@ proto.setUserContext = function setUserContext(user) {
 proto.setExtraContext = function setExtraContext(extra) {
   if (domain.active && domain.active.sentryContext) {
     domain.active.sentryContext.extra = extend({}, domain.active.sentryContext.extra, extra);
+  } else {
+    this._globalContext.extra = extend({}, this._globalContext.extra, extra);
   }
   return this;
 };
@@ -235,11 +243,13 @@ proto.setExtraContext = function setExtraContext(extra) {
 proto.setTagsContext = function setTagsContext(tags) {
   if (domain.active && domain.active.sentryContext) {
     domain.active.sentryContext.tags = extend({}, domain.active.sentryContext.tags, tags);
+  } else {
+    this._globalContext.tags = extend({}, this._globalContext.tags, tags);
   }
   return this;
 };
 
-proto.patchGlobal = function patchGlobal(cb) {
+proto.install = proto.patchGlobal = function patchGlobal(cb) {
   module.exports.patchGlobal(this, cb);
   return this;
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,20 +8,11 @@ var uuid = require('node-uuid');
 var transports = require('./transports');
 var nodeUtil = require('util'); // nodeUtil to avoid confusion with "utils"
 var events = require('events');
+var domain = require('domain');
 
 module.exports.version = require('../package.json').version;
 
-var extend = Object.assign || function (target) {
-  for (var i = 1; i < arguments.length; i++) {
-    var source = arguments[i];
-    for (var key in source) {
-      if (Object.prototype.hasOwnProperty.call(source, key)) {
-        target[key] = source[key];
-      }
-    }
-  }
-  return target;
-};
+var extend = utils.extend;
 
 var Client = function Client(dsn, options) {
   if (arguments.length === 0) {
@@ -180,6 +171,35 @@ proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
   return result;
 };
 
+/* The onErr param here is sort of ugly and won't typically be used
+ * but it lets us write the requestHandler middleware in terms of this function.
+ * We could consider getting rid of it and just duplicating the domain
+ * instantiation etc logic in the requestHandler middleware
+ */
+proto.runWithContext = function (ctx, cb, onErr) {
+  if (!cb && typeof ctx === 'function') {
+    cb = ctx;
+    ctx = {};
+  }
+  var self = this;
+  var ctxDomain = domain.create();
+  ctxDomain.sentryContext = ctx;
+  if (typeof onErr !== 'function') {
+    onErr = function (err) {
+      self.captureError(err, ctxDomain.sentryContext, function (results) {
+        // sup, not really much to do here; maybe emit events from client?
+      });
+    };
+  }
+  ctxDomain.on('error', onErr);
+
+  // should we nextTick this? need to determine whether it makes any difference
+  process.nextTick(function () {
+    ctxDomain.run(cb);
+  });
+  return ctxDomain;
+};
+
 /*
  * Set/clear a user to be sent along with the payload.
  *
@@ -187,7 +207,10 @@ proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
  * @return {Raven}
  */
 proto.setUserContext = function setUserContext(user) {
-  this._globalContext.user = user;
+  if (domain.active && domain.active.sentryContext) {
+    domain.active.sentryContext.user = extend({}, domain.active.sentryContext.user, user);
+  }
+  return this;
 };
 
 /*
@@ -197,7 +220,9 @@ proto.setUserContext = function setUserContext(user) {
  * @return {Raven}
  */
 proto.setExtraContext = function setExtraContext(extra) {
-  this._globalContext.extra = extend({}, this._globalContext.extra, extra);
+  if (domain.active && domain.active.sentryContext) {
+    domain.active.sentryContext.extra = extend({}, domain.active.sentryContext.extra, extra);
+  }
   return this;
 };
 
@@ -208,7 +233,9 @@ proto.setExtraContext = function setExtraContext(extra) {
  * @return {Raven}
  */
 proto.setTagsContext = function setTagsContext(tags) {
-  this._globalContext.tags = extend({}, this._globalContext.tags, tags);
+  if (domain.active && domain.active.sentryContext) {
+    domain.active.sentryContext.tags = extend({}, domain.active.sentryContext.tags, tags);
+  }
   return this;
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -173,7 +173,7 @@ proto.captureException = function captureException(err, kwargs, cb) {
 proto.captureError = function () {
   utils.consoleAlert('client.captureError has been deprecated and will be removed in v2.0');
   this.captureException.apply(this, arguments);
-}
+};
 
 proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
   if (!cb && typeof kwargs === 'function') {
@@ -192,28 +192,82 @@ proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
  * We could consider getting rid of it and just duplicating the domain
  * instantiation etc logic in the requestHandler middleware
  */
-proto.context = function (ctx, cb, onErr) {
-  if (!cb && typeof ctx === 'function') {
-    cb = ctx;
+proto.context = function (ctx, func, onErr) {
+  if (!func && typeof ctx === 'function') {
+    func = ctx;
     ctx = {};
   }
+
+  // todo/note: raven-js takes an args param to do apply(this, args)
+  // i don't think it's correct/necessary to bind this to the wrap call
+  // and i don't know if we need to support the args param; it's undocumented
+  return this.wrap(ctx, func, onErr).apply(null);
+};
+
+proto.wrap = function (options, func, onErr) {
+  if (!func && typeof options === 'function') {
+    func = options;
+    options = {};
+  }
+
+  var wrapDomain = domain.create();
+  // todo: better property name than sentryContext, maybe __raven__ or sth?
+  wrapDomain.sentryContext = options;
+
   var self = this;
-  var ctxDomain = domain.create();
-  ctxDomain.sentryContext = ctx;
   if (typeof onErr !== 'function') {
     onErr = function (err) {
-      self.captureError(err, ctxDomain.sentryContext, function (results) {
-        // sup, not really much to do here; maybe emit events from client?
-      });
+      self.captureException(err, wrapDomain.sentryContext);
     };
   }
-  ctxDomain.on('error', onErr);
 
-  // should we nextTick this? need to determine whether it makes any difference
-  process.nextTick(function () {
-    ctxDomain.run(cb);
+  wrapDomain.on('error', function (err) {
+    onErr(err, wrapDomain.sentryContext);
   });
-  return ctxDomain;
+
+  var wrapped = function wrapped() {
+    // todo make sure this is the best/right way to do this
+    var args = Array.prototype.slice.call(arguments);
+    args.unshift(func);
+    wrapDomain.run.apply(wrapDomain, args);
+  };
+
+  for (var property in func) {
+    if ({}.hasOwnProperty.call(func, property)) {
+      wrapped[property] = func[property];
+    }
+  }
+  wrapped.prototype = func.prototype;
+  wrapped.__raven__ = true;
+  wrapped.__inner__ = func;
+  wrapped.__domain__ = wrapDomain;
+
+  return wrapped;
+};
+
+proto.setContext = function setContext(ctx) {
+  if (!domain.active) {
+    utils.consoleAlert('attempt to setContext outside context scope');
+  } else {
+    domain.active.sentryContext = ctx;
+  }
+};
+
+// todo consider this naming; maybe "mergeContext" instead?
+proto.updateContext = function updateContext(ctx) {
+  if (!domain.active) {
+    utils.consoleAlert('attempt to updateContext outside context scope');
+  } else {
+    domain.active.sentryContext = extend({}, domain.active.sentryContext, ctx);
+  }
+};
+
+proto.getContext = function setContext(ctx) {
+  if (!domain.active) {
+    utils.consoleAlert('attempt to getContext outside context scope');
+    return null;
+  }
+  return domain.active.sentryContext;
 };
 
 /*
@@ -252,12 +306,7 @@ proto.setTagsContext = function setTagsContext(tags) {
   return this;
 };
 
-proto.install = proto.patchGlobal = function patchGlobal(cb) {
-  module.exports.patchGlobal(this, cb);
-  return this;
-};
-
-module.exports.patchGlobal = function patchGlobal(client, cb) {
+var patchGlobal = function patchGlobal(client, cb) {
   // handle when the first argument is the callback, with no client specified
   if (typeof client === 'function') {
     cb = client;
@@ -298,4 +347,13 @@ module.exports.patchGlobal = function patchGlobal(client, cb) {
       utils.consoleAlert('uncaughtException: ' + client.getIdent(result));
     });
   });
+};
+
+proto.install = function (cb) {
+  patchGlobal(this, cb);
+  return this;
+};
+
+proto.patchGlobal = module.exports.patchGlobal = function (cb) {
+  utils.consoleAlert('patchGlobal has been deprecated and will be removed in v2.0');
 };

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -2,6 +2,8 @@
 
 var raven = require('../client');
 var parsers = require('../parsers');
+var extend = require('../utils').extend;
+var domain = require('domain');
 
 // Legacy support
 var connectMiddleware = function (client) {
@@ -19,6 +21,9 @@ connectMiddleware.errorHandler = function (client) {
     if (status < 500) return next(err);
 
     var kwargs = parsers.parseRequest(req);
+    if (domain.active && domain.active.sentryContext) {
+      kwargs = extend(kwargs, domain.active.sentryContext);
+    }
     return client.captureError(err, kwargs, function (result) {
       res.sentry = client.getIdent(result);
       next(err, req, res);
@@ -29,11 +34,8 @@ connectMiddleware.errorHandler = function (client) {
 // Ensures asynchronous exceptions are routed to the errorHandler. This
 // should be the **first** item listed in middleware.
 connectMiddleware.requestHandler = function (client) {
-  var domain = require('domain');
   return function (req, res, next) {
-    var reqDomain = domain.create();
-    reqDomain.on('error', next);
-    return reqDomain.run(next);
+    client.runWithContext({}, next, next);
   };
 };
 

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -24,7 +24,7 @@ connectMiddleware.errorHandler = function (client) {
     if (domain.active && domain.active.sentryContext) {
       kwargs = extend(kwargs, domain.active.sentryContext);
     }
-    return client.captureError(err, kwargs, function (result) {
+    return client.captureException(err, kwargs, function (result) {
       res.sentry = client.getIdent(result);
       next(err, req, res);
     });

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -35,7 +35,7 @@ connectMiddleware.errorHandler = function (client) {
 // should be the **first** item listed in middleware.
 connectMiddleware.requestHandler = function (client) {
   return function (req, res, next) {
-    client.runWithContext({}, next, next);
+    client.context({}, next, next);
   };
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,18 @@ var protocolMap = {
   https: 443
 };
 
+module.exports.extend = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+  return target;
+};
+
 module.exports.getAuthHeader = function getAuthHeader(timestamp, apiKey, apiSecret) {
   var header = ['Sentry sentry_version=5'];
   header.push('sentry_timestamp=' + timestamp);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,9 +8,24 @@ var path = require('path');
 var lsmod = require('lsmod');
 var stacktrace = require('stack-trace');
 
+var version = require('../package.json').version;
+
 var protocolMap = {
   http: 80,
   https: 443
+};
+
+var consoleAlerts = {};
+
+module.exports.disableConsoleAlerts = function disableConsoleAlerts() {
+  consoleAlerts = false;
+};
+
+module.exports.consoleAlert = function consoleAlert(msg) {
+  if (consoleAlerts && !(msg in consoleAlerts)) {
+    consoleAlerts[msg] = true;
+    console.log('raven@' + version + ' alert: ' + msg);
+  }
 };
 
 module.exports.extend = Object.assign || function (target) {

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -227,10 +227,10 @@ describe('raven.Client', function () {
         kwargs.message.should.equal('Error: wtf?');
         kwargs.should.have.property('exception');
         var stack = kwargs.exception[0].stacktrace;
-        stack.frames[stack.frames.length - 1].function.should.equal('Client.captureError');
+        stack.frames[stack.frames.length - 1].function.should.equal('Client.captureException');
         done();
       };
-      client.captureError('wtf?');
+      client.captureException('wtf?');
     });
 
     it('should send an Error to Sentry server on another port', function (done) {


### PR DESCRIPTION
- Adds client.runWithContext
- Makes express middleware use runWithContext
- Makes client.setUserContext, client.setExtraContext, and client.setTagsContext play with the nicely with the domain context from runWithContext

Tests are currently broken, working on fixing existing tests and adding tests for runWithContext.

To discuss:
- Naming, API, etc
- `onErr` param in runWithContext vs duplicating domain stuff in express middleware

Example use:
```javascript
var ctx = {
  user: {
    username: 'lewis'
  },
  tags: {...}
};
client.runWithContext(ctx, function () {
  throw new Error(...); // will be caught and reported with user and tags from ctx
});
```
or:
```javascript
// omit ctx object
client.runWithContext(function () {
  client.setUserContext({ username: 'lewis' });
  // async stuff happens in between
  throw new Error(...); // will be reported with username: lewis
});
```
/cc @benvinegar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-node/207)
<!-- Reviewable:end -->
