### PR TITLE
call next() inside onError example

### DIFF
--- a/docs/integrations/connect.rst
+++ b/docs/integrations/connect.rst
@@ -15,6 +15,7 @@ Connect
       // and optionally displayed to the user for support.
       res.statusCode = 500;
       res.end(res.sentry+'\n');
+      next();
   }
 
   connect(

--- a/docs/integrations/express.rst
+++ b/docs/integrations/express.rst
@@ -11,6 +11,7 @@ Express
         // and optionally displayed to the user for support.
         res.statusCode = 500;
         res.end(res.sentry+'\n');
+        next();
     }
 
     // The request handler must be the first item


### PR DESCRIPTION
I ran into an issue by removing the ``next`` function param from ``onError`` in the Express middleware documentation that was causing my app to crash when an error happened. I did this because Eslint was complaining about ``no-unused-vars``. 

I added ``next();`` to the end of the function and now everything is happy.
