### PR TITLE
Make capture* callbacks fire after sending, more API cleanup/singletonization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ node_js:
   - "0.8"
   - "0.10"
   - "0.12"
-  - "4.0"
-  - "5.0"
+  - "4"
+  - "5"
+  - "6"
+  - "node"
 before_install:
   - "npm install --upgrade npm -g"

--- a/lib/client.js
+++ b/lib/client.js
@@ -114,7 +114,13 @@ extend(Raven.prototype, {
       kwargs = this.dataCallback(kwargs);
     }
 
-    this._enabled && this.send(kwargs, cb);
+    if (this._enabled) {
+      this.send(kwargs, cb);
+    } else {
+      setImmediate(function () {
+        cb(null, eventId);
+      });
+    }
   },
 
   send: function send(kwargs, cb) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -80,6 +80,7 @@ extend(Raven.prototype, {
   process: function process(eventId, kwargs, cb) {
     // prod codepaths shouldn't hit this branch, for testing
     if (typeof eventId === 'object') {
+      cb = kwargs;
       kwargs = eventId;
       eventId = this.generateEventId();
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -10,303 +10,338 @@ var nodeUtil = require('util'); // nodeUtil to avoid confusion with "utils"
 var events = require('events');
 var domain = require('domain');
 
-module.exports.version = require('../package.json').version;
-
 var extend = utils.extend;
 
-module.exports.disableConsoleAlerts = utils.disableConsoleAlerts;
+function Raven() {}
 
-var Client = function Client(dsn, options) {
-  if (arguments.length === 0) {
-    // no arguments, use default from environment
-    dsn = process.env.SENTRY_DSN;
-    options = {};
-  }
-  if (typeof dsn === 'object') {
-    // They must only be passing through options
-    options = dsn;
-    dsn = process.env.SENTRY_DSN;
-  }
-  options = options || {};
+nodeUtil.inherits(Raven, events.EventEmitter);
 
-  this.raw_dsn = dsn;
-  this.dsn = utils.parseDSN(dsn);
-  this.name = options.name || process.env.SENTRY_NAME || require('os').hostname();
-  this.root = options.root || process.cwd();
-  this.transport = options.transport || transports[this.dsn.protocol];
-  this.release = options.release || process.env.SENTRY_RELEASE || '';
-  this.environment = options.environment || process.env.SENTRY_ENVIRONMENT || '';
-
-  this.loggerName = options.logger || '';
-  this.dataCallback = options.dataCallback;
-
-  if (!this.dsn) {
-    utils.consoleAlert('no DSN provided, error reporting disabled');
-  }
-
-  if (this.dsn.protocol === 'https') {
-    // In case we want to provide our own SSL certificates / keys
-    this.ca = options.ca || null;
-  }
-
-  // enabled if a dsn is set
-  this._enabled = !!this.dsn;
-
-  var globalContext = this._globalContext = {};
-  if (options.tags) {
-    globalContext.tags = options.tags;
-  }
-  if (options.extra) {
-    globalContext.extra = options.extra;
-  }
-
-  this.on('error', function (err) {
-    utils.consoleAlert('failed to send exception to sentry: ' + err.message);
-  });
-};
-nodeUtil.inherits(Client, events.EventEmitter);
-var proto = Client.prototype;
-
-module.exports.Client = Client;
-
-module.exports.config = function (dsn, options) {
-  return new Client(dsn, options);
-};
-
-proto.getIdent =
-  proto.get_ident = function getIdent(result) {
-    return result.id;
-  };
-
-proto.process = function process(kwargs) {
-  kwargs.modules = utils.getModules();
-  kwargs.server_name = kwargs.server_name || this.name;
-
-  if (typeof process.version !== 'undefined') {
-    kwargs.extra.node = process.version;
-  }
-
-  kwargs.environment = kwargs.environment || this.environment;
-  kwargs.extra = extend({}, this._globalContext.extra, kwargs.extra);
-  kwargs.tags = extend({}, this._globalContext.tags, kwargs.tags);
-
-  kwargs.logger = kwargs.logger || this.loggerName;
-  kwargs.event_id = uuid().replace(/-/g, '');
-  kwargs.timestamp = new Date().toISOString().split('.')[0];
-  kwargs.project = this.dsn.project_id;
-  kwargs.platform = 'node';
-
-  if (this._globalContext.user) {
-    kwargs.user = this._globalContext.user || kwargs.user;
-  }
-
-  // Only include release information if it is set
-  if (this.release) {
-    kwargs.release = this.release;
-  }
-
-  var ident = {
-    id: kwargs.event_id
-  };
-
-  if (this.dataCallback) {
-    kwargs = this.dataCallback(kwargs);
-  }
-
-  // this will happen asynchronously. We don't care about its response.
-  this._enabled && this.send(kwargs, ident);
-
-  return ident;
-};
-
-proto.send = function send(kwargs, ident) {
-  var self = this;
-
-  var skwargs = stringify(kwargs);
-
-  zlib.deflate(skwargs, function (err, buff) {
-    var message = buff.toString('base64'),
-        timestamp = new Date().getTime(),
-        headers = {
-          'X-Sentry-Auth': utils.getAuthHeader(timestamp, self.dsn.public_key, self.dsn.private_key),
-          'Content-Type': 'application/octet-stream',
-          'Content-Length': message.length
-        };
-
-    self.transport.send(self, message, headers, ident);
-  });
-};
-
-proto.captureMessage = function captureMessage(message, kwargs, cb) {
-  if (!cb && typeof kwargs === 'function') {
-    cb = kwargs;
-    kwargs = {};
-  } else {
-    kwargs = kwargs || {};
-  }
-  var result = this.process(parsers.parseText(message, kwargs));
-  cb && cb(result);
-  return result;
-};
-
-proto.captureException = function captureException(err, kwargs, cb) {
-  if (!(err instanceof Error)) {
-    // This handles when someone does:
-    //   throw "something awesome";
-    // We synthesize an Error here so we can extract a (rough) stack trace.
-    err = new Error(err);
-  }
-
-  var self = this;
-  if (!cb && typeof kwargs === 'function') {
-    cb = kwargs;
-    kwargs = {};
-  } else {
-    kwargs = kwargs || {};
-  }
-  parsers.parseError(err, kwargs, function (kw) {
-    var result = self.process(kw);
-    cb && cb(result);
-  });
-};
-
-proto.captureError = function () {
-  utils.consoleAlert('client.captureError has been deprecated and will be removed in v2.0');
-  this.captureException.apply(this, arguments);
-};
-
-proto.captureQuery = function captureQuery(query, engine, kwargs, cb) {
-  if (!cb && typeof kwargs === 'function') {
-    cb = kwargs;
-    kwargs = {};
-  } else {
-    kwargs = kwargs || {};
-  }
-  var result = this.process(parsers.parseQuery(query, engine, kwargs));
-  cb && cb(result);
-  return result;
-};
-
-/* The onErr param here is sort of ugly and won't typically be used
- * but it lets us write the requestHandler middleware in terms of this function.
- * We could consider getting rid of it and just duplicating the domain
- * instantiation etc logic in the requestHandler middleware
- */
-proto.context = function (ctx, func, onErr) {
-  if (!func && typeof ctx === 'function') {
-    func = ctx;
-    ctx = {};
-  }
-
-  // todo/note: raven-js takes an args param to do apply(this, args)
-  // i don't think it's correct/necessary to bind this to the wrap call
-  // and i don't know if we need to support the args param; it's undocumented
-  return this.wrap(ctx, func, onErr).apply(null);
-};
-
-proto.wrap = function (options, func, onErr) {
-  if (!func && typeof options === 'function') {
-    func = options;
-    options = {};
-  }
-
-  var wrapDomain = domain.create();
-  // todo: better property name than sentryContext, maybe __raven__ or sth?
-  wrapDomain.sentryContext = options;
-
-  var self = this;
-  if (typeof onErr !== 'function') {
-    onErr = function (err) {
-      self.captureException(err, wrapDomain.sentryContext);
-    };
-  }
-
-  wrapDomain.on('error', function (err) {
-    onErr(err, wrapDomain.sentryContext);
-  });
-
-  var wrapped = function wrapped() {
-    // todo make sure this is the best/right way to do this
-    var args = Array.prototype.slice.call(arguments);
-    args.unshift(func);
-    wrapDomain.run.apply(wrapDomain, args);
-  };
-
-  for (var property in func) {
-    if ({}.hasOwnProperty.call(func, property)) {
-      wrapped[property] = func[property];
+extend(Raven.prototype, {
+  config: function config(dsn, options) {
+    if (arguments.length === 0) {
+      // no arguments, use default from environment
+      dsn = process.env.SENTRY_DSN;
+      options = {};
     }
+    if (typeof dsn === 'object') {
+      // They must only be passing through options
+      options = dsn;
+      dsn = process.env.SENTRY_DSN;
+    }
+    options = options || {};
+
+    this.raw_dsn = dsn;
+    this.dsn = utils.parseDSN(dsn);
+    this.name = options.name || process.env.SENTRY_NAME || require('os').hostname();
+    this.root = options.root || process.cwd();
+    this.transport = options.transport || transports[this.dsn.protocol];
+    this.release = options.release || process.env.SENTRY_RELEASE || '';
+    this.environment = options.environment || process.env.SENTRY_ENVIRONMENT || '';
+
+    this.loggerName = options.logger || '';
+    this.dataCallback = options.dataCallback;
+
+    if (!this.dsn) {
+      utils.consoleAlert('no DSN provided, error reporting disabled');
+    }
+
+    if (this.dsn.protocol === 'https') {
+      // In case we want to provide our own SSL certificates / keys
+      this.ca = options.ca || null;
+    }
+
+    // enabled if a dsn is set
+    this._enabled = !!this.dsn;
+
+    var globalContext = this._globalContext = {};
+    if (options.tags) {
+      globalContext.tags = options.tags;
+    }
+    if (options.extra) {
+      globalContext.extra = options.extra;
+    }
+
+    this.on('error', function (err) {
+      utils.consoleAlert('failed to send exception to sentry: ' + err.message);
+    });
+
+    return this;
+  },
+
+  install: function install(cb) {
+    patchGlobal(this, cb);
+    return this;
+  },
+
+  generateEventId: function generateEventId() {
+    return uuid().replace(/-/g, '');
+  },
+
+  process: function process(eventId, kwargs, cb) {
+    // prod codepaths shouldn't hit this branch, for testing
+    if (typeof eventId === 'object') {
+      kwargs = eventId;
+      eventId = this.generateEventId();
+    }
+
+    kwargs.modules = utils.getModules();
+    kwargs.server_name = kwargs.server_name || this.name;
+
+    if (typeof process.version !== 'undefined') {
+      kwargs.extra.node = process.version;
+    }
+
+    kwargs.environment = kwargs.environment || this.environment;
+    kwargs.extra = extend({}, this._globalContext.extra, kwargs.extra);
+    kwargs.tags = extend({}, this._globalContext.tags, kwargs.tags);
+
+    kwargs.logger = kwargs.logger || this.loggerName;
+    kwargs.event_id = eventId;
+    kwargs.timestamp = new Date().toISOString().split('.')[0];
+    kwargs.project = this.dsn.project_id;
+    kwargs.platform = 'node';
+
+    if (this._globalContext.user) {
+      kwargs.user = this._globalContext.user || kwargs.user;
+    }
+
+    // Only include release information if it is set
+    if (this.release) {
+      kwargs.release = this.release;
+    }
+
+    if (this.dataCallback) {
+      kwargs = this.dataCallback(kwargs);
+    }
+
+    this._enabled && this.send(kwargs, cb);
+  },
+
+  send: function send(kwargs, cb) {
+    var self = this;
+    var skwargs = stringify(kwargs);
+    var eventId = kwargs.event_id;
+
+    zlib.deflate(skwargs, function (err, buff) {
+      var message = buff.toString('base64'),
+          timestamp = new Date().getTime(),
+          headers = {
+            'X-Sentry-Auth': utils.getAuthHeader(timestamp, self.dsn.public_key, self.dsn.private_key),
+            'Content-Type': 'application/octet-stream',
+            'Content-Length': message.length
+          };
+
+      self.transport.send(self, message, headers, eventId, cb);
+    });
+  },
+
+  captureMessage: function captureMessage(message, kwargs, cb) {
+    if (!cb && typeof kwargs === 'function') {
+      cb = kwargs;
+      kwargs = {};
+    } else {
+      kwargs = kwargs || {};
+    }
+    var eventId = this.generateEventId();
+    this.process(eventId, parsers.parseText(message, kwargs), cb);
+
+    return eventId;
+  },
+
+  captureException: function captureException(err, kwargs, cb) {
+    if (!(err instanceof Error)) {
+      // This handles when someone does:
+      //   throw "something awesome";
+      // We synthesize an Error here so we can extract a (rough) stack trace.
+      err = new Error(err);
+    }
+
+    if (!cb && typeof kwargs === 'function') {
+      cb = kwargs;
+      kwargs = {};
+    } else {
+      kwargs = kwargs || {};
+    }
+
+    var self = this;
+    var eventId = this.generateEventId();
+    parsers.parseError(err, kwargs, function (kw) {
+      self.process(eventId, kw, cb);
+    });
+
+    return eventId;
+  },
+
+  captureQuery: function captureQuery(query, engine, kwargs, cb) {
+    if (!cb && typeof kwargs === 'function') {
+      cb = kwargs;
+      kwargs = {};
+    } else {
+      kwargs = kwargs || {};
+    }
+
+    var eventId = this.generateEventId();
+    this.process(eventId, parsers.parseQuery(query, engine, kwargs), cb);
+
+    return eventId;
+  },
+
+  /* The onErr param here is sort of ugly and won't typically be used
+   * but it lets us write the requestHandler middleware in terms of this function.
+   * We could consider getting rid of it and just duplicating the domain
+   * instantiation etc logic in the requestHandler middleware
+   */
+  context: function (ctx, func, onErr) {
+    if (!func && typeof ctx === 'function') {
+      func = ctx;
+      ctx = {};
+    }
+
+    // todo/note: raven-js takes an args param to do apply(this, args)
+    // i don't think it's correct/necessary to bind this to the wrap call
+    // and i don't know if we need to support the args param; it's undocumented
+    return this.wrap(ctx, func, onErr).apply(null);
+  },
+
+  wrap: function (options, func, onErr) {
+    if (!func && typeof options === 'function') {
+      func = options;
+      options = {};
+    }
+
+    var wrapDomain = domain.create();
+    // todo: better property name than sentryContext, maybe __raven__ or sth?
+    wrapDomain.sentryContext = options;
+
+    var self = this;
+    if (typeof onErr !== 'function') {
+      onErr = function (err) {
+        self.captureException(err, wrapDomain.sentryContext);
+      };
+    }
+
+    wrapDomain.on('error', function (err) {
+      onErr(err, wrapDomain.sentryContext);
+    });
+
+    var wrapped = function wrapped() {
+      // todo make sure this is the best/right way to do this
+      var args = Array.prototype.slice.call(arguments);
+      args.unshift(func);
+      wrapDomain.run.apply(wrapDomain, args);
+    };
+
+    for (var property in func) {
+      if ({}.hasOwnProperty.call(func, property)) {
+        wrapped[property] = func[property];
+      }
+    }
+    wrapped.prototype = func.prototype;
+    wrapped.__raven__ = true;
+    wrapped.__inner__ = func;
+    wrapped.__domain__ = wrapDomain;
+
+    return wrapped;
+  },
+
+  setContext: function setContext(ctx) {
+    if (!domain.active) {
+      utils.consoleAlert('attempt to setContext outside context scope');
+    } else {
+      domain.active.sentryContext = ctx;
+    }
+  },
+
+  // todo consider this naming; maybe "mergeContext" instead?
+  updateContext: function updateContext(ctx) {
+    if (!domain.active) {
+      utils.consoleAlert('attempt to updateContext outside context scope');
+    } else {
+      domain.active.sentryContext = extend({}, domain.active.sentryContext, ctx);
+    }
+  },
+
+  getContext: function setContext(ctx) {
+    if (!domain.active) {
+      utils.consoleAlert('attempt to getContext outside context scope');
+      return null;
+    }
+    return domain.active.sentryContext;
+  },
+
+  /*
+   * Set/clear a user to be sent along with the payload.
+   *
+   * @param {object} user An object representing user data [optional]
+   * @return {Raven}
+   */
+  setUserContext: function setUserContext(user) {
+    utils.consoleAlert('setUserContext has been deprecated and will be removed in v2.0');
+    this._globalContext.user = user;
+    return this;
+  },
+
+  /*
+   * Merge extra attributes to be sent along with the payload.
+   *
+   * @param {object} extra An object representing extra data [optional]
+   * @return {Raven}
+   */
+  setExtraContext: function setExtraContext(extra) {
+    utils.consoleAlert('setExtraContext has been deprecated and will be removed in v2.0');
+    this._globalContext.extra = extend({}, this._globalContext.extra, extra);
+    return this;
+  },
+
+  /*
+   * Merge tags to be sent along with the payload.
+   *
+   * @param {object} tags An object representing tags [optional]
+   * @return {Raven}
+   */
+  setTagsContext: function setTagsContext(tags) {
+    utils.consoleAlert('setTagsContext has been deprecated and will be removed in v2.0');
+    this._globalContext.tags = extend({}, this._globalContext.tags, tags);
+    return this;
   }
-  wrapped.prototype = func.prototype;
-  wrapped.__raven__ = true;
-  wrapped.__inner__ = func;
-  wrapped.__domain__ = wrapDomain;
+});
 
-  return wrapped;
-};
 
-proto.setContext = function setContext(ctx) {
-  if (!domain.active) {
-    utils.consoleAlert('attempt to setContext outside context scope');
-  } else {
-    domain.active.sentryContext = ctx;
+// Deprecations
+extend(Raven.prototype, {
+  getIdent: function getIdent(result) {
+    utils.consoleAlert('getIdent has been deprecated and will be removed in v2.0');
+    return result;
+  },
+  captureError: function captureError() {
+    utils.consoleAlert('captureError has been deprecated and will be removed in v2.0');
+    this.captureException.apply(this, arguments);
+  },
+  patchGlobal: function (cb) {
+    utils.consoleAlert('patchGlobal has been deprecated and will be removed in v2.0');
+    return this.install(cb);
   }
-};
+});
+Raven.prototype.get_ident = Raven.prototype.getIdent;
 
-// todo consider this naming; maybe "mergeContext" instead?
-proto.updateContext = function updateContext(ctx) {
-  if (!domain.active) {
-    utils.consoleAlert('attempt to updateContext outside context scope');
-  } else {
-    domain.active.sentryContext = extend({}, domain.active.sentryContext, ctx);
-  }
-};
+// Maintain old API compat, need to make sure arguments length is preserved
+function Client(dsn, options) {
+  var ravenInstance = new Raven();
+  return ravenInstance.config.apply(ravenInstance, arguments);
+}
+nodeUtil.inherits(Client, Raven);
 
-proto.getContext = function setContext(ctx) {
-  if (!domain.active) {
-    utils.consoleAlert('attempt to getContext outside context scope');
-    return null;
-  }
-  return domain.active.sentryContext;
-};
+// Singleton-by-default but not strictly enforced
+// todo these extra export props are sort of an adhoc mess, better way to manage?
+var defaultInstance = new Raven();
+defaultInstance.Client = Client;
+defaultInstance.patchGlobal = patchGlobal;
+defaultInstance.version = require('../package.json').version;
+defaultInstance.disableConsoleAlerts = utils.disableConsoleAlerts;
 
-/*
- * Set/clear a user to be sent along with the payload.
- *
- * @param {object} user An object representing user data [optional]
- * @return {Raven}
- */
-proto.setUserContext = function setUserContext(user) {
-  utils.consoleAlert('setUserContext has been deprecated and will be removed in v2.0');
-  this._globalContext.user = user;
-  return this;
-};
+module.exports = defaultInstance;
 
-/*
- * Merge extra attributes to be sent along with the payload.
- *
- * @param {object} extra An object representing extra data [optional]
- * @return {Raven}
- */
-proto.setExtraContext = function setExtraContext(extra) {
-  utils.consoleAlert('setExtraContext has been deprecated and will be removed in v2.0');
-  this._globalContext.extra = extend({}, this._globalContext.extra, extra);
-  return this;
-};
-
-/*
- * Merge tags to be sent along with the payload.
- *
- * @param {object} tags An object representing tags [optional]
- * @return {Raven}
- */
-proto.setTagsContext = function setTagsContext(tags) {
-  utils.consoleAlert('setTagsContext has been deprecated and will be removed in v2.0');
-  this._globalContext.tags = extend({}, this._globalContext.tags, tags);
-  return this;
-};
-
-var patchGlobal = function patchGlobal(client, cb) {
+function patchGlobal(client, cb) {
   // handle when the first argument is the callback, with no client specified
   if (typeof client === 'function') {
     cb = client;
@@ -316,7 +351,7 @@ var patchGlobal = function patchGlobal(client, cb) {
     client = new Client(client);
   }
   // at the end, if we still don't have a Client, let's make one!
-  !(client instanceof Client) && (client = new Client());
+  !(client instanceof Raven) && (client = new Client());
 
   var called = false;
   process.on('uncaughtException', function (err) {
@@ -343,19 +378,7 @@ var patchGlobal = function patchGlobal(client, cb) {
 
     called = true;
 
-    return client.captureException(err, function (result) {
-      utils.consoleAlert('uncaughtException: ' + client.getIdent(result));
-    });
+    var eventId = client.captureException(err);
+    return utils.consoleAlert('uncaughtException: ' + eventId);
   });
-};
-
-proto.install = function (cb) {
-  patchGlobal(this, cb);
-  return this;
-};
-
-proto.patchGlobal = module.exports.patchGlobal = function (cb) {
-  utils.consoleAlert('patchGlobal has been deprecated and will be removed in v2.0');
-  patchGlobal(this, cb);
-  return this;
-};
+}

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -14,7 +14,7 @@ function HTTPTransport(options) {
   this.options = options || {};
 }
 util.inherits(HTTPTransport, Transport);
-HTTPTransport.prototype.send = function (client, message, headers, ident) {
+HTTPTransport.prototype.send = function (client, message, headers, eventId, cb) {
   var options = {
     hostname: client.dsn.host,
     path: client.dsn.path + 'api/' + client.dsn.project_id + '/store/',
@@ -31,7 +31,8 @@ HTTPTransport.prototype.send = function (client, message, headers, ident) {
   var req = this.transport.request(options, function (res) {
     res.setEncoding('utf8');
     if (res.statusCode >= 200 && res.statusCode < 300) {
-      client.emit('logged', ident);
+      client.emit('logged', eventId);
+      cb && cb(null, eventId);
     } else {
       var reason = res.headers['x-sentry-error'];
       var e = new Error('HTTP Error (' + res.statusCode + '): ' + reason);
@@ -40,8 +41,9 @@ HTTPTransport.prototype.send = function (client, message, headers, ident) {
       e.reason = reason;
       e.sendMessage = message;
       e.requestHeaders = headers;
-      e.ident = ident;
+      e.eventId = eventId;
       client.emit('error', e);
+      cb && cb(e);
     }
     // force the socket to drain
     var noop = function () {};

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -50,8 +50,14 @@ HTTPTransport.prototype.send = function (client, message, headers, eventId, cb) 
     res.on('data', noop);
     res.on('end', noop);
   });
+
+  var cbFired = false;
   req.on('error', function (e) {
     client.emit('error', e);
+    if (!cbFired) {
+      cb && cb(e);
+      cbFired = true;
+    }
   });
   req.end(message);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var raven = require('./client');
 var fs = require('fs');
 var url = require('url');
 var transports = require('./transports');
@@ -8,7 +7,7 @@ var path = require('path');
 var lsmod = require('lsmod');
 var stacktrace = require('stack-trace');
 
-var version = require('../package.json').version;
+var ravenVersion = require('../package.json').version;
 
 var protocolMap = {
   http: 80,
@@ -24,7 +23,7 @@ module.exports.disableConsoleAlerts = function disableConsoleAlerts() {
 module.exports.consoleAlert = function consoleAlert(msg) {
   if (consoleAlerts && !(msg in consoleAlerts)) {
     consoleAlerts[msg] = true;
-    console.log('raven@' + version + ' alert: ' + msg);
+    console.log('raven@' + ravenVersion + ' alert: ' + msg);
   }
 };
 
@@ -43,7 +42,7 @@ module.exports.extend = Object.assign || function (target) {
 module.exports.getAuthHeader = function getAuthHeader(timestamp, apiKey, apiSecret) {
   var header = ['Sentry sentry_version=5'];
   header.push('sentry_timestamp=' + timestamp);
-  header.push('sentry_client=raven-node/' + raven.version);
+  header.push('sentry_client=raven-node/' + ravenVersion);
   header.push('sentry_key=' + apiKey);
   header.push('sentry_secret=' + apiSecret);
   return header.join(', ');

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -5,6 +5,8 @@ var raven = require('../'),
     nock = require('nock'),
     zlib = require('zlib');
 
+raven.utils.disableConsoleAlerts();
+
 var dsn = 'https://public:private@app.getsentry.com/269';
 
 var _oldConsoleWarn = console.warn;
@@ -142,9 +144,7 @@ describe('raven.Client', function () {
 
   describe('#getIdent()', function () {
     it('should match', function () {
-      var result = {
-        id: 'c988bf5cb7db4653825c92f6864e7206',
-      };
+      var result = 'c988bf5cb7db4653825c92f6864e7206';
       client.getIdent(result).should.equal('c988bf5cb7db4653825c92f6864e7206');
     });
   });
@@ -227,7 +227,7 @@ describe('raven.Client', function () {
         kwargs.message.should.equal('Error: wtf?');
         kwargs.should.have.property('exception');
         var stack = kwargs.exception[0].stacktrace;
-        stack.frames[stack.frames.length - 1].function.should.equal('Client.captureException');
+        stack.frames[stack.frames.length - 1].function.should.equal('Raven.captureException');
         done();
       };
       client.captureException('wtf?');
@@ -348,7 +348,6 @@ describe('raven.Client', function () {
 
   describe('#process()', function () {
     it('should respect dataCallback', function (done) {
-      var client = new raven.Client(dsn);
       var scope = nock('https://app.getsentry.com')
         .filteringRequestBody(/.*/, '*')
         .post('/api/269/store/', '*')

--- a/test/raven.parsers.js
+++ b/test/raven.parsers.js
@@ -286,11 +286,11 @@ describe('raven.parsers', function () {
           url: '/some/path?foo=bar',
         };
 
+        // doing assertion backwards here because query_string has no prototype
+        // https://github.com/nodejs/node/pull/6289
         var parsed = raven.parsers.parseRequest(mockReq);
-
-        parsed.request.query_string.should.eql({
-          foo: 'bar'
-        });
+        var expected = { foo: 'bar' };
+        expected.should.eql(parsed.request.query_string);
       });
     });
 


### PR DESCRIPTION
Short version: addresses #213, moves the API to follow raven-js almost exactly, still maintains BC in almost all ways with old API

Details:
- captureException etc now fire their callbacks after sending to the server, as in #213 
- Moved everything to a Raven class instead of Client, following raven-js pattern/API
  - We now export a default Raven instance, leading to almost-identical usage to raven-js
  - Still have a Client wrapper for bc/multi-instance capabilities
- Does some other polishing/cleanups on the API changes
- Adds glue to maintain backwards compat with old API as much as possible
  - None of the changes to tests actually affect any existing public API usage patterns at all

The only public API usage affected by this should be the one described by @mattrobenolt in #213, and the realistic caveat to run into from it is that existing code looking at `eventId`s from `capture*` callbacks will now get `null` instead of a string.

/cc @benvinegar 