### PR TITLE
Middleware fixes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -359,6 +359,32 @@ extend(Raven.prototype, {
    */
   setShouldSendCallback: function (callback) {
     return this.setCallbackHelper('shouldSendCallback', callback);
+  },
+
+  requestHandler: function () {
+    var self = this;
+    return function (req, res, next) {
+      self.context({}, next, next);
+    };
+  },
+
+  errorHandler: function () {
+    var self = this;
+    return function (err, req, res, next) {
+      var status = err.status || err.statusCode || err.status_code || 500;
+
+      // skip anything not marked as an internal server error
+      if (status < 500) return next(err);
+
+      var kwargs = parsers.parseRequest(req);
+      if (domain.active && domain.active.sentryContext) {
+        kwargs = extend(kwargs, domain.active.sentryContext);
+      }
+      return self.captureException(err, kwargs, function (sendErr, eventId) {
+        res.sentry = eventId;
+        next(err);
+      });
+    };
   }
 });
 
@@ -383,6 +409,7 @@ Raven.prototype.get_ident = Raven.prototype.getIdent;
 
 // Maintain old API compat, need to make sure arguments length is preserved
 function Client(dsn, options) {
+  if (dsn instanceof Client) return dsn;
   var ravenInstance = new Raven();
   return ravenInstance.config.apply(ravenInstance, arguments);
 }

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -1,9 +1,6 @@
 'use strict';
 
-var raven = require('../client');
-var parsers = require('../parsers');
-var extend = require('../utils').extend;
-var domain = require('domain');
+var Raven = require('../client');
 
 // Legacy support
 var connectMiddleware = function (client) {
@@ -13,30 +10,15 @@ var connectMiddleware = function (client) {
 // Error handler. This should be the last item listed in middleware, but
 // before any other error handlers.
 connectMiddleware.errorHandler = function (client) {
-  // client = client instanceof raven.Client ? client : new raven.Client(client);
-  return function (err, req, res, next) {
-    var status = err.status || err.statusCode || err.status_code || 500;
-
-    // skip anything not marked as an internal server error
-    if (status < 500) return next(err);
-
-    var kwargs = parsers.parseRequest(req);
-    if (domain.active && domain.active.sentryContext) {
-      kwargs = extend(kwargs, domain.active.sentryContext);
-    }
-    return client.captureException(err, kwargs, function (err, eventId) {
-      res.sentry = eventId;
-      next(err);
-    });
-  };
+  client = client instanceof Raven.Client ? client : new Raven.Client(client);
+  return client.errorHandler();
 };
 
 // Ensures asynchronous exceptions are routed to the errorHandler. This
 // should be the **first** item listed in middleware.
 connectMiddleware.requestHandler = function (client) {
-  return function (req, res, next) {
-    client.context({}, next, next);
-  };
+  client = client instanceof Raven.Client ? client : new Raven.Client(client);
+  return client.requestHandler();
 };
 
 module.exports = connectMiddleware;

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -24,9 +24,9 @@ connectMiddleware.errorHandler = function (client) {
     if (domain.active && domain.active.sentryContext) {
       kwargs = extend(kwargs, domain.active.sentryContext);
     }
-    return client.captureException(err, kwargs, function (result) {
-      res.sentry = client.getIdent(result);
-      next(err, req, res);
+    return client.captureException(err, kwargs, function (err, eventId) {
+      res.sentry = eventId;
+      next(err);
     });
   };
 };

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -13,7 +13,7 @@ var connectMiddleware = function (client) {
 // Error handler. This should be the last item listed in middleware, but
 // before any other error handlers.
 connectMiddleware.errorHandler = function (client) {
-  client = client instanceof raven.Client ? client : new raven.Client(client);
+  // client = client instanceof raven.Client ? client : new raven.Client(client);
   return function (err, req, res, next) {
     var status = err.status || err.statusCode || err.status_code || 500;
 


### PR DESCRIPTION
Adds new Raven-instance-oriented middleware-returning-methods:
```javascript
var Raven = require('raven');
Raven.config(dsn).install();
...
app.use(Raven.requestHandler());
...
app.use(Raven.errorHandler());
```

Also BC-ifies old raven.middleware.express.* interface to delegate to these after ensuring existence of client instance.

/cc @MaxBittker @benvinegar