### PR TITLE
Simplify context methods to fall back on instance-global context

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -293,10 +293,8 @@ extend(Raven.prototype, {
     return this;
   },
 
-  // todo consider this naming; maybe "mergeContext" instead?
-  updateContext: function updateContext(ctx) {
-    var targetCtx = this.getContext();
-    targetCtx = extend({}, targetCtx, ctx);
+  mergeContext: function mergeContext(ctx) {
+    extend(this.getContext(), ctx);
     return this;
   },
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -287,28 +287,21 @@ extend(Raven.prototype, {
   },
 
   setContext: function setContext(ctx) {
-    if (!domain.active) {
-      utils.consoleAlert('attempt to setContext outside context scope');
-    } else {
-      domain.active.sentryContext = ctx;
-    }
+    // eslint-disable-next-line no-unused-vars
+    var targetCtx = this.getContext();
+    targetCtx = ctx;
+    return this;
   },
 
   // todo consider this naming; maybe "mergeContext" instead?
   updateContext: function updateContext(ctx) {
-    if (!domain.active) {
-      utils.consoleAlert('attempt to updateContext outside context scope');
-    } else {
-      domain.active.sentryContext = extend({}, domain.active.sentryContext, ctx);
-    }
+    var targetCtx = this.getContext();
+    targetCtx = extend({}, targetCtx, ctx);
+    return this;
   },
 
   getContext: function getContext() {
-    if (!domain.active) {
-      utils.consoleAlert('attempt to getContext outside context scope');
-      return null;
-    }
-    return domain.active.sentryContext;
+    return domain.active ? domain.active.sentryContext : this._globalContext;
   },
 
   /*
@@ -318,8 +311,8 @@ extend(Raven.prototype, {
    * @return {Raven}
    */
   setUserContext: function setUserContext(user) {
-    utils.consoleAlert('setUserContext has been deprecated and will be removed in v2.0');
-    this._globalContext.user = user;
+    var targetCtx = this.getContext();
+    targetCtx.user = user;
     return this;
   },
 
@@ -330,8 +323,8 @@ extend(Raven.prototype, {
    * @return {Raven}
    */
   setExtraContext: function setExtraContext(extra) {
-    utils.consoleAlert('setExtraContext has been deprecated and will be removed in v2.0');
-    this._globalContext.extra = extend({}, this._globalContext.extra, extra);
+    var targetCtx = this.getContext();
+    targetCtx.extra = extend({}, targetCtx.extra, extra);
     return this;
   },
 
@@ -342,8 +335,8 @@ extend(Raven.prototype, {
    * @return {Raven}
    */
   setTagsContext: function setTagsContext(tags) {
-    utils.consoleAlert('setTagsContext has been deprecated and will be removed in v2.0');
-    this._globalContext.tags = extend({}, this._globalContext.tags, tags);
+    var targetCtx = this.getContext();
+    targetCtx.tags = extend({}, targetCtx.tags, tags);
     return this;
   },
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -310,9 +310,8 @@ extend(Raven.prototype, {
    * @param {object} user An object representing user data [optional]
    * @return {Raven}
    */
-  setUserContext: function setUserContext(user) {
-    var targetCtx = this.getContext();
-    targetCtx.user = user;
+  setUserContext: function setUserContext() {
+    utils.consoleAlert('setUserContext has been deprecated and will be removed in v2.0; use setContext instead');
     return this;
   },
 
@@ -322,9 +321,8 @@ extend(Raven.prototype, {
    * @param {object} extra An object representing extra data [optional]
    * @return {Raven}
    */
-  setExtraContext: function setExtraContext(extra) {
-    var targetCtx = this.getContext();
-    targetCtx.extra = extend({}, targetCtx.extra, extra);
+  setExtraContext: function setExtraContext() {
+    utils.consoleAlert('setExtraContext has been deprecated and will be removed in v2.0; use setContext instead');
     return this;
   },
 
@@ -334,9 +332,8 @@ extend(Raven.prototype, {
    * @param {object} tags An object representing tags [optional]
    * @return {Raven}
    */
-  setTagsContext: function setTagsContext(tags) {
-    var targetCtx = this.getContext();
-    targetCtx.tags = extend({}, targetCtx.tags, tags);
+  setTagsContext: function setTagsContext() {
+    utils.consoleAlert('setTagsContext has been deprecated and will be removed in v2.0; use setContext instead');
     return this;
   },
 
@@ -391,9 +388,9 @@ extend(Raven.prototype, {
       if (status < 500) return next(err);
 
       var kwargs = parsers.parseRequest(req);
-      var eventId = self.captureException(err, kwargs)
+      var eventId = self.captureException(err, kwargs);
       res.sentry = eventId;
-      next(err);
+      return next(err);
     };
   }
 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -93,6 +93,11 @@ extend(Raven.prototype, {
       eventId = this.generateEventId();
     }
 
+    var domainContext = domain.active && domain.active.sentryContext || {};
+    kwargs.user = extend({}, this._globalContext.user, domainContext.user, kwargs.user);
+    kwargs.tags = extend({}, this._globalContext.tags, domainContext.tags, kwargs.tags);
+    kwargs.extra = extend({}, this._globalContext.extra, domainContext.extra, kwargs.extra);
+
     kwargs.modules = utils.getModules();
     kwargs.server_name = kwargs.server_name || this.name;
 
@@ -101,18 +106,11 @@ extend(Raven.prototype, {
     }
 
     kwargs.environment = kwargs.environment || this.environment;
-    kwargs.extra = extend({}, this._globalContext.extra, kwargs.extra);
-    kwargs.tags = extend({}, this._globalContext.tags, kwargs.tags);
-
     kwargs.logger = kwargs.logger || this.loggerName;
     kwargs.event_id = eventId;
     kwargs.timestamp = new Date().toISOString().split('.')[0];
     kwargs.project = this.dsn.project_id;
     kwargs.platform = 'node';
-
-    if (this._globalContext.user) {
-      kwargs.user = this._globalContext.user || kwargs.user;
-    }
 
     // Only include release information if it is set
     if (this.release) {
@@ -287,9 +285,11 @@ extend(Raven.prototype, {
   },
 
   setContext: function setContext(ctx) {
-    // eslint-disable-next-line no-unused-vars
-    var targetCtx = this.getContext();
-    targetCtx = ctx;
+    if (domain.active) {
+      domain.active.sentryContext = ctx;
+    } else {
+      this._globalContext = ctx;
+    }
     return this;
   },
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -391,13 +391,9 @@ extend(Raven.prototype, {
       if (status < 500) return next(err);
 
       var kwargs = parsers.parseRequest(req);
-      if (domain.active && domain.active.sentryContext) {
-        kwargs = extend(kwargs, domain.active.sentryContext);
-      }
-      return self.captureException(err, kwargs, function (sendErr, eventId) {
-        res.sentry = eventId;
-        next(err);
-      });
+      var eventId = self.captureException(err, kwargs)
+      res.sentry = eventId;
+      next(err);
     };
   }
 });

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -748,9 +748,11 @@ describe('raven.Client', function () {
       release: 'version1'
     });
 
-    client.setUserContext({
-      email: 'matt@example.com',
-      id: '123'
+    client.setContext({
+      user: {
+        email: 'matt@example.com',
+        id: '123'
+      }
     });
 
     client.on('logged', function () {
@@ -836,55 +838,6 @@ describe('raven.Client', function () {
           scope.done();
         });
       });
-    });
-  });
-
-  describe('#setUserContext()', function () {
-    it('should add the user object to the globalContext', function () {
-      var user = {
-        email: 'matt@example.com', // <-- my fave user
-        id: '123'
-      };
-
-      client.setUserContext(user);
-
-      client._globalContext.user.should.equal(user);
-    });
-  });
-
-  describe('#setExtraContext()', function () {
-    it('should merge the extra data object into the globalContext', function () {
-      // when no pre-existing context
-      client.setExtraContext({
-        bar: 'baz'
-      });
-
-      client._globalContext.extra.should.have.property('bar', 'baz');
-
-      client.setExtraContext({ // should merge onto previous
-        foo: 'bar'
-      });
-
-      client._globalContext.extra.should.have.property('foo', 'bar');
-      client._globalContext.extra.should.have.property('bar', 'baz');
-    });
-  });
-
-  describe('#setTagsContext()', function () {
-    it('should merge the extra data object into the globalContext', function () {
-      // when no pre-existing context
-      client.setTagsContext({
-        browser: 'Chrome'
-      });
-
-      client._globalContext.tags.should.have.property('browser', 'Chrome');
-
-      client.setTagsContext({ // should merge onto previous
-        platform: 'OS X'
-      });
-
-      client._globalContext.tags.should.have.property('browser', 'Chrome');
-      client._globalContext.tags.should.have.property('platform', 'OS X');
     });
   });
 


### PR DESCRIPTION
Still todo on this PR: make sure captureException etc, we have the correct context-state-merging-hierarchy going on; stuff passed to capture method > stuff in domain context > stuff in instance-global context.