### PR TITLE
Move set*Context to deprecations, fix captureError return value

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -302,39 +302,6 @@ extend(Raven.prototype, {
     return domain.active ? domain.active.sentryContext : this._globalContext;
   },
 
-  /*
-   * Set/clear a user to be sent along with the payload.
-   *
-   * @param {object} user An object representing user data [optional]
-   * @return {Raven}
-   */
-  setUserContext: function setUserContext() {
-    utils.consoleAlert('setUserContext has been deprecated and will be removed in v2.0; use setContext instead');
-    return this;
-  },
-
-  /*
-   * Merge extra attributes to be sent along with the payload.
-   *
-   * @param {object} extra An object representing extra data [optional]
-   * @return {Raven}
-   */
-  setExtraContext: function setExtraContext() {
-    utils.consoleAlert('setExtraContext has been deprecated and will be removed in v2.0; use setContext instead');
-    return this;
-  },
-
-  /*
-   * Merge tags to be sent along with the payload.
-   *
-   * @param {object} tags An object representing tags [optional]
-   * @return {Raven}
-   */
-  setTagsContext: function setTagsContext() {
-    utils.consoleAlert('setTagsContext has been deprecated and will be removed in v2.0; use setContext instead');
-    return this;
-  },
-
   setCallbackHelper: function (propertyName, callback) {
     var original = this[propertyName];
     if (typeof callback === 'function') {
@@ -402,13 +369,25 @@ extend(Raven.prototype, {
   },
   captureError: function captureError() {
     utils.consoleAlert('captureError has been deprecated and will be removed in v2.0');
-    this.captureException.apply(this, arguments);
+    return this.captureException.apply(this, arguments);
   },
   patchGlobal: function (cb) {
     utils.consoleAlert('patchGlobal has been deprecated and will be removed in v2.0');
     registerExceptionHandler(this, cb);
     return this;
-  }
+  },
+  setUserContext: function setUserContext() {
+    utils.consoleAlert('setUserContext has been deprecated and will be removed in v2.0; use setContext instead');
+    return this;
+  },
+  setExtraContext: function setExtraContext() {
+    utils.consoleAlert('setExtraContext has been deprecated and will be removed in v2.0; use setContext instead');
+    return this;
+  },
+  setTagsContext: function setTagsContext() {
+    utils.consoleAlert('setTagsContext has been deprecated and will be removed in v2.0; use setContext instead');
+    return this;
+  },
 });
 Raven.prototype.get_ident = Raven.prototype.getIdent;
 


### PR DESCRIPTION
Quick change, moved stuff and made `captureError` return the eventId like `captureException`.