### PR TITLE
Version 1.0.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debugging",
     "exceptions"
   ],
-  "version": "0.12.1",
+  "version": "1.0.0-beta.0",
   "repository": "git://github.com/getsentry/raven-node.git",
   "author": "Matt Robenolt <matt@ydekproductions.com>",
   "license": "BSD-2-Clause",

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -25,7 +25,7 @@ function restoreConsoleWarn() {
 
 describe('raven.version', function () {
   it('should be valid', function () {
-    raven.version.should.match(/^\d+\.\d+\.\d+(-\w+)?$/);
+    raven.version.should.match(/^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$/);
   });
 
   it('should match package.json', function () {


### PR DESCRIPTION
Based on reading https://www.npmjs.com/package/npm-bump and https://docs.npmjs.com/getting-started/using-tags, the plan is to set the version to this and then do:
```
npm publish --tag beta
```
which will result in installation instructions being:
```
npm install raven@beta
```
or specifically *this first* beta:
```
npm install raven@1.0.0-beta.0
```
and will avoid installing the beta when someone just does `npm install raven`.

/cc @benvinegar 