### PR TITLE
Add instrumentation tests for node-http against its own tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 coverage/
+test/instrumentation/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ node_js:
   - "node"
 before_install:
   - "npm install --upgrade npm -g"
+script: npm run test-full

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "pretest": "npm install && npm run lint",
     "test": "NODE_ENV=test istanbul cover _mocha  -- --reporter dot && NODE_ENV=test node_modules/coffee-script/bin/coffee ./test/run.coffee",
+    "test-full": "npm run test && cd test/instrumentation && ./run.sh",
     "lint": "node_modules/eslint/bin/eslint.js ."
   },
   "engines": {

--- a/test/instrumentation/README.md
+++ b/test/instrumentation/README.md
@@ -1,0 +1,25 @@
+# Instrumentation tests
+
+These are tests where we run our breadcrumb instrumentation on a module, then run the instrumented module's original test suite to make sure we didn't break anything.
+
+We don't run these tests in CI; they have one-off harnesses and various requirements to run which may be tricky to provide in CI, and the results of these tests are unlikely to change without significant changes to instrumentation logic which would warrant running them manually during development.
+
+We have the following tests:
+- node core http (`node-http.test.js`)
+
+We may add in the future:
+- postgres, mysql, etc
+- other database drivers
+- any other node core modules we choose to instrument
+
+### Usage:
+In short, you need to have node checked out to the proper version, then run `node node-http.test.js "/Path/to/node"`.
+
+Exact steps to run, starting from the directory above `raven-node`:
+```bash
+git clone git@github.com:nodejs/node.git
+cd node
+git checkout -b v7.2.0 # replace 7.2.0 with whatever version of node you have installed
+cd ../raven-node/test/instrumentation
+node node-http.test.js "../../../node" # or /Path/to/your/clone/of/node"
+```

--- a/test/instrumentation/README.md
+++ b/test/instrumentation/README.md
@@ -2,8 +2,6 @@
 
 These are tests where we run our breadcrumb instrumentation on a module, then run the instrumented module's original test suite to make sure we didn't break anything.
 
-We don't run these tests in CI; they have one-off harnesses and various requirements to run which may be tricky to provide in CI, and the results of these tests are unlikely to change without significant changes to instrumentation logic which would warrant running them manually during development.
-
 We have the following tests:
 - node core http (`node-http.test.js`)
 
@@ -13,13 +11,13 @@ We may add in the future:
 - any other node core modules we choose to instrument
 
 ### Usage:
-In short, you need to have node checked out to the proper version, then run `node node-http.test.js "/Path/to/node"`.
-
-Exact steps to run, starting from the directory above `raven-node`:
-```bash
-git clone git@github.com:nodejs/node.git
-cd node
-git checkout -b v7.2.0 # replace 7.2.0 with whatever version of node you have installed
-cd ../raven-node/test/instrumentation
-node node-http.test.js "../../../node" # or /Path/to/your/clone/of/node"
+We don't run these by default as part of `npm test` since they require a heavy download and take ~a minute to run, but we run them in CI. You can run them locally with:
 ```
+npm run test-full
+```
+Or:
+```bash
+cd test/instrumentation
+./run.sh
+```
+This will check what version of node you have, grab the source of that version, then run against that http test suite.

--- a/test/instrumentation/node-http.test.js
+++ b/test/instrumentation/node-http.test.js
@@ -1,0 +1,29 @@
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var child_process = require('child_process');
+
+var nodeRoot = process.argv[2];
+var testRoot = path.join(nodeRoot, 'test/parallel');
+var testFiles = fs.readdirSync(testRoot).filter(function (filename) {
+  return filename.startsWith('test-http');
+});
+
+var failedTests = [];
+var numSuccesses = 0;
+testFiles.forEach(function (filename) {
+  var testModulePath = path.join(testRoot, filename);
+  try {
+    child_process.execFileSync('node', ['--allow-natives-syntax', '--expose_gc', 'run-node-http-test.js', testModulePath], { stdio: 'ignore' });
+    console.log('✓ ' + filename);
+    numSuccesses++;
+  } catch (e) {
+    // non-zero exit code -> test failure
+    failedTests.push(filename);
+    console.log('X ' + filename + ' - error!');
+  }
+});
+
+console.log('Finished, failures: ' + failedTests.length + ', successes: ' + numSuccesses);
+console.log(failedTests);
+console.log('Note: we are not worried about test-http-pipeline-flood.js failing.');

--- a/test/instrumentation/node-http.test.js
+++ b/test/instrumentation/node-http.test.js
@@ -3,10 +3,13 @@ var fs = require('fs');
 var path = require('path');
 var child_process = require('child_process');
 
+// running on pre-4.0 is hard, somewhat different test scheme
+if (process.version < 'v4') process.exit(0);
+
 var nodeRoot = process.argv[2];
 var testRoot = path.join(nodeRoot, 'test/parallel');
 var testFiles = fs.readdirSync(testRoot).filter(function (filename) {
-  return filename.startsWith('test-http');
+  return filename.indexOf('test-http') === 0;
 });
 
 var failedTests = [];
@@ -26,8 +29,12 @@ testFiles.forEach(function (filename) {
 
 console.log('Finished, failures: ' + failedTests.length + ', successes: ' + numSuccesses);
 
+// pipeline-flood is a harness issue with how it expects argvs
+// header response splitting is something about becoming more strict on allowed chars in headers
+// not worried about either one; they also fail without our instrumentation
 var knownFailures = [
-  'test-http-pipeline-flood.js'
+  'test-http-pipeline-flood.js',
+  'test-http-header-response-splitting.js'
 ];
 
 var didPass = failedTests.every(function (filename) {

--- a/test/instrumentation/node-http.test.js
+++ b/test/instrumentation/node-http.test.js
@@ -25,5 +25,18 @@ testFiles.forEach(function (filename) {
 });
 
 console.log('Finished, failures: ' + failedTests.length + ', successes: ' + numSuccesses);
-console.log(failedTests);
-console.log('Note: we are not worried about test-http-pipeline-flood.js failing.');
+
+var knownFailures = [
+  'test-http-pipeline-flood.js'
+];
+
+var didPass = failedTests.every(function (filename) {
+  return knownFailures.indexOf(filename) !== -1;
+});
+if (!didPass) {
+  console.log('Some unexpected failures, failing...')
+  process.exit(1);
+} else {
+  console.log('All failures were known/expected, passing...')
+  process.exit(0);
+}

--- a/test/instrumentation/run-node-http-test.js
+++ b/test/instrumentation/run-node-http-test.js
@@ -1,0 +1,16 @@
+'use strict';
+var Raven = require('../../');
+// We never actually report any errors, just getting Raven to play ball
+var sentryDsn = 'https://fake:dsn@app.getsentry.com/12345';
+
+Raven.disableConsoleAlerts();
+Raven.config(sentryDsn, {
+  autoBreadcrumbs: {
+    console: false,
+    http: true,
+  }
+}).install();
+process.removeAllListeners('uncaughtException');
+
+var testModulePath = process.argv[process.argv.length - 1];
+require(testModulePath);

--- a/test/instrumentation/run.sh
+++ b/test/instrumentation/run.sh
@@ -1,11 +1,11 @@
 # /bin/sh
 version=`node -v`
-version2=`echo $version | cut -c 2-`
-folder="node-$version2"
+versionMinusV=`echo $version | cut -c 2-`
+nodeRoot="node-$versionMinusV"
 
-if [ ! -d $folder ]; then
+if [ ! -d $nodeRoot ]; then
   url="https://codeload.github.com/nodejs/node/tar.gz/$version"
   curl $url -o "$version.tar.gz"
-  tar -xvf "$version.tar.gz"
+  tar -xf "$version.tar.gz"
 fi
-node "node-http.test.js" `pwd`/$folder
+node "node-http.test.js" `pwd`/$nodeRoot

--- a/test/instrumentation/run.sh
+++ b/test/instrumentation/run.sh
@@ -1,0 +1,11 @@
+# /bin/sh
+version=`node -v`
+version2=`echo $version | cut -c 2-`
+folder="node-$version2"
+
+if [ ! -d $folder ]; then
+  url="https://codeload.github.com/nodejs/node/tar.gz/$version"
+  curl $url -o "$version.tar.gz"
+  tar -xvf "$version.tar.gz"
+fi
+node "node-http.test.js" `pwd`/$folder


### PR DESCRIPTION
/cc @benvinegar @maxbittker

This is a sort of one-off harness to run node's core http module's tests against our instrumented version of it. This gives me a good amount of confidence that our instrumentation doesn't blow anything up, but I'm still working on some raven-level "did we catch the breadcrumb off the instrumentation" type tests in addition to these.

Can you go through this readme to make sure you can run them on your system? It'll take a few minutes to clone node, but running the tests only takes ~40 seconds.