### PR TITLE
Breadcrumb tests

### DIFF
--- a/lib/breadcrumbs.js
+++ b/lib/breadcrumbs.js
@@ -71,10 +71,19 @@ var wrappers = {
       var self = this;
       OrigClientRequest.call(self, options, cb);
 
-      var method = self.method;
-      var url = (self.agent && self.agent.protocol || '') + '//' +
-                (self._headers && self._headers.host || '') +
-                self.path;
+      // We could just always grab these from self.agent, self.method, self._headers, self.path, etc
+      // but certain other http-instrumenting libraries (like nock, which we use for tests) fail to
+      // maintain the guarantee that after calling OrigClientRequest, those fields will be populated
+      var url, method;
+      if (typeof options === 'string') {
+        url = options;
+        method = 'GET';
+      } else {
+        url = (options.protocol || '') + '//' +
+              (options.hostname || options.host || '') +
+              (options.path || '/');
+        method = options.method || 'GET';
+      }
 
       // Don't capture breadcrumb for our own requests
       if (!Raven.dsn || url.indexOf(Raven.dsn.public_key) === -1) {

--- a/lib/breadcrumbs.js
+++ b/lib/breadcrumbs.js
@@ -86,7 +86,7 @@ var wrappers = {
       }
 
       // Don't capture breadcrumb for our own requests
-      if (!Raven.dsn || url.indexOf(Raven.dsn.public_key) === -1) {
+      if (!Raven.dsn || url.indexOf(Raven.dsn.host) === -1) {
         self.once('response', function (response) {
           Raven.captureBreadcrumb({
             type: 'http',

--- a/lib/breadcrumbs.js
+++ b/lib/breadcrumbs.js
@@ -18,6 +18,8 @@ function fill(obj, name, replacement, track) {
   }
 }
 
+var originals = [];
+
 var wrappers = {
   console: function (Raven) {
     var wrapConsoleMethod = function (level) {
@@ -50,7 +52,7 @@ var wrappers = {
 
           originalConsoleLevel.apply(console, args);
         };
-      });
+      }, originals);
     };
 
     ['debug', 'info', 'warn', 'error', 'log'].forEach(wrapConsoleMethod);
@@ -94,20 +96,26 @@ var wrappers = {
       }
     };
     util.inherits(ClientRequest, OrigClientRequest);
-    http.ClientRequest = ClientRequest;
+    fill(http, 'ClientRequest', function () {
+      return ClientRequest;
+    }, originals);
 
     // http.request orig refs module-internal ClientRequest, not exported one, so
     // it still points at orig ClientRequest after our monkeypatch; these reimpls
     // just get that reference updated to use our new ClientRequest
-    http.request = function (options, cb) {
-      return new http.ClientRequest(options, cb);
-    };
+    fill(http, 'request', function () {
+      return function (options, cb) {
+        return new http.ClientRequest(options, cb);
+      };
+    }, originals);
 
-    http.get = function (options, cb) {
-      var req = http.request(options, cb);
-      req.end();
-      return req;
-    };
+    fill(http, 'get', function () {
+      return function (options, cb) {
+        var req = http.request(options, cb);
+        req.end();
+        return req;
+      };
+    }, originals);
   },
 
   postgres: function (Raven) {
@@ -121,6 +129,7 @@ var wrappers = {
       });
       origQuery.call(this, text);
     };
+    originals.push([pg.Connection.prototype, 'query', origQuery]);
   }
 };
 
@@ -133,6 +142,18 @@ function instrument(key, Raven) {
   }
 }
 
+function restoreOriginals() {
+  var original;
+  // eslint-disable-next-line no-cond-assign
+  while (original = originals.shift()) {
+    var obj = original[0];
+    var name = original[1];
+    var orig = original[2];
+    obj[name] = orig;
+  }
+}
+
 module.exports = {
-  instrument: instrument
+  instrument: instrument,
+  restoreOriginals: restoreOriginals
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -117,6 +117,20 @@ extend(Raven.prototype, {
     return this;
   },
 
+  uninstall: function uninstall() {
+    if (!this.installed) return this;
+
+    autoBreadcrumbs.restoreOriginals();
+
+    // todo: this works for tests for now, but isn't what we ultimately want to be doing
+    process.removeAllListeners('uncaughtException');
+    process.removeAllListeners('unhandledRejection');
+
+    this.installed = false;
+
+    return this;
+  },
+
   generateEventId: function generateEventId() {
     return uuid().replace(/-/g, '');
   },


### PR DESCRIPTION
There's a bit of general test suite refactoring that could be done here, and I need to refactor our `uncaughtexception`/`unhandledrejection` handler stuff a bit to make `.uninstall` remove only our handlers instead of all of them, but this at least exercises our breadcrumb instrumentation and capturing. I'll worry about that stuff after the breadcrumbs PR lands.