### PR TITLE
Update connect middleware for 1.0

### DIFF
--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -7,7 +7,7 @@ var connectMiddleware = function (client) {
   return connectMiddleware.errorHandler(client);
 };
 
-var returnOrCreateClient = function(client) {
+var returnOrCreateClient = function (client) {
   // Use an existing client if an instance of a client, or configure a new one.
   // Note: the module returns a default instance of a Raven client.
   // `Raven.constructor` accesses its constructor in order to perform an

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -7,17 +7,25 @@ var connectMiddleware = function (client) {
   return connectMiddleware.errorHandler(client);
 };
 
+var returnOrCreateClient = function(client) {
+  // Use an existing client if an instance of a client, or configure a new one.
+  // Note: the module returns a default instance of a Raven client.
+  // `Raven.constructor` accesses its constructor in order to perform an
+  // `instanceof` check on the `client` argument
+  return client instanceof Raven.constructor ? client : Raven.config(client);
+};
+
 // Error handler. This should be the last item listed in middleware, but
 // before any other error handlers.
 connectMiddleware.errorHandler = function (client) {
-  client = client instanceof Raven.Client ? client : new Raven.Client(client);
+  client = returnOrCreateClient(client);
   return client.errorHandler();
 };
 
 // Ensures asynchronous exceptions are routed to the errorHandler. This
 // should be the **first** item listed in middleware.
 connectMiddleware.requestHandler = function (client) {
-  client = client instanceof Raven.Client ? client : new Raven.Client(client);
+  client = returnOrCreateClient(client);
   return client.requestHandler();
 };
 

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -7,25 +7,25 @@ var connectMiddleware = function (client) {
   return connectMiddleware.errorHandler(client);
 };
 
-var returnOrCreateClient = function (client) {
+var returnOrCreateClient = function (clientOrDSN) {
   // Use an existing client if an instance of a client, or configure a new one.
   // Note: the module returns a default instance of a Raven client.
   // `Raven.constructor` accesses its constructor in order to perform an
   // `instanceof` check on the `client` argument
-  return client instanceof Raven.constructor ? client : Raven.config(client);
+  return clientOrDSN instanceof Raven.constructor ? clientOrDSN : Raven.config(clientOrDSN);
 };
 
 // Error handler. This should be the last item listed in middleware, but
 // before any other error handlers.
-connectMiddleware.errorHandler = function (client) {
-  client = returnOrCreateClient(client);
+connectMiddleware.errorHandler = function (clientOrDSN) {
+  var client = returnOrCreateClient(clientOrDSN);
   return client.errorHandler();
 };
 
 // Ensures asynchronous exceptions are routed to the errorHandler. This
 // should be the **first** item listed in middleware.
-connectMiddleware.requestHandler = function (client) {
-  client = returnOrCreateClient(client);
+connectMiddleware.requestHandler = function (clientOrDSN) {
+  var client = returnOrCreateClient(clientOrDSN);
   return client.requestHandler();
 };
 


### PR DESCRIPTION
Several changes:

- Reuse of an existing client

```js
client instanceof Raven.Client
```

returned `false`, preventing an existing client from being used.

- Create raven instances with `Raven.config` instead of `new Raven.Client`

- DRYer code. Made the existing client check into a reusable function.