### PR TITLE
Fix middleware backwards compatibility

### DIFF
--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -16,15 +16,18 @@ var getClient = function (clientOrDSN) {
 // Error handler. This should be the last item listed in middleware, but
 // before any other error handlers.
 connectMiddleware.errorHandler = function (clientOrDSN) {
-  utils.consoleAlert('top-level Raven.middleware.errorHandler has been deprecated and will be removed in v2.0; use Raven.errorHandler() instance method instead');
+  utils.consoleAlert('top-level Raven.middleware.*.errorHandler has been deprecated and will be removed in v2.0; use Raven.errorHandler() instance method instead');
   return getClient(clientOrDSN).errorHandler();
 };
 
 // Ensures asynchronous exceptions are routed to the errorHandler. This
 // should be the **first** item listed in middleware.
 connectMiddleware.requestHandler = function (clientOrDSN) {
-  utils.consoleAlert('top-level Raven.middleware.requestHandler has been deprecated and will be removed in v2.0; use Raven.requestHandler() instance method instead');
+  utils.consoleAlert('top-level Raven.middleware.*.requestHandler has been deprecated and will be removed in v2.0; use Raven.requestHandler() instance method instead');
   return getClient(clientOrDSN).requestHandler();
 };
+
+// for testing purposes only; not gonna worry about a nicer test exposure scheme since this code is going away soon
+connectMiddleware.getClient = getClient;
 
 module.exports = connectMiddleware;

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -7,17 +7,25 @@ var connectMiddleware = function (client) {
   return connectMiddleware.errorHandler(client);
 };
 
+var returnOrCreateClient = function (clientOrDSN) {
+  // Use an existing client if an instance of a client, or configure a new one.
+  // Note: the module returns a default instance of a Raven client.
+  // `Raven.constructor` accesses its constructor in order to perform an
+  // `instanceof` check on the `client` argument
+  return clientOrDSN instanceof Raven.constructor ? clientOrDSN : Raven.config(clientOrDSN);
+};
+
 // Error handler. This should be the last item listed in middleware, but
 // before any other error handlers.
-connectMiddleware.errorHandler = function (client) {
-  client = client instanceof Raven.Client ? client : new Raven.Client(client);
+connectMiddleware.errorHandler = function (clientOrDSN) {
+  var client = returnOrCreateClient(clientOrDSN);
   return client.errorHandler();
 };
 
 // Ensures asynchronous exceptions are routed to the errorHandler. This
 // should be the **first** item listed in middleware.
-connectMiddleware.requestHandler = function (client) {
-  client = client instanceof Raven.Client ? client : new Raven.Client(client);
+connectMiddleware.requestHandler = function (clientOrDSN) {
+  var client = returnOrCreateClient(clientOrDSN);
   return client.requestHandler();
 };
 

--- a/lib/middleware/connect.js
+++ b/lib/middleware/connect.js
@@ -1,32 +1,30 @@
 'use strict';
 
 var Raven = require('../client');
+var utils = require('../utils');
 
 // Legacy support
 var connectMiddleware = function (client) {
   return connectMiddleware.errorHandler(client);
 };
 
-var returnOrCreateClient = function (clientOrDSN) {
-  // Use an existing client if an instance of a client, or configure a new one.
-  // Note: the module returns a default instance of a Raven client.
-  // `Raven.constructor` accesses its constructor in order to perform an
-  // `instanceof` check on the `client` argument
-  return clientOrDSN instanceof Raven.constructor ? clientOrDSN : Raven.config(clientOrDSN);
+var getClient = function (clientOrDSN) {
+  // Raven is an instance, so use Raven.constructor for instanceof check
+  return clientOrDSN instanceof Raven.constructor ? clientOrDSN : new Raven.Client(clientOrDSN);
 };
 
 // Error handler. This should be the last item listed in middleware, but
 // before any other error handlers.
 connectMiddleware.errorHandler = function (clientOrDSN) {
-  var client = returnOrCreateClient(clientOrDSN);
-  return client.errorHandler();
+  utils.consoleAlert('top-level Raven.middleware.errorHandler has been deprecated and will be removed in v2.0; use Raven.errorHandler() instance method instead');
+  return getClient(clientOrDSN).errorHandler();
 };
 
 // Ensures asynchronous exceptions are routed to the errorHandler. This
 // should be the **first** item listed in middleware.
 connectMiddleware.requestHandler = function (clientOrDSN) {
-  var client = returnOrCreateClient(clientOrDSN);
-  return client.requestHandler();
+  utils.consoleAlert('top-level Raven.middleware.requestHandler has been deprecated and will be removed in v2.0; use Raven.requestHandler() instance method instead');
+  return getClient(clientOrDSN).requestHandler();
 };
 
 module.exports = connectMiddleware;

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -1004,3 +1004,18 @@ describe('raven.Client', function () {
     });
   });
 });
+
+describe('raven.middleware', function () {
+  it('should use an instance passed to it instead of making a new one', function () {
+    var client = new raven.Client(dsn);
+    raven.middleware.express.getClient(client).should.equal(client);
+  });
+
+  it('should make a new instance when passed a DSN string', function () {
+    var client1 = new raven.Client(dsn);
+    var client2 = raven.middleware.express.getClient(dsn);
+    client2.should.not.equal(raven);
+    client2.should.not.equal(client1);
+    client2.should.be.an.instanceof(raven.constructor);
+  });
+});


### PR DESCRIPTION
- Changed to use `instanceof Raven.constructor` instead of `instanceof Raven.client`
- Added deprecation warnings; these toplevel functions are the old way to do it and people should have their own instances and use the instance methods instead, rather than having to pass in an instance or let one be created for them.

Based on #245 from @dhritzkiv. Will merge into master and also cherry pick into a `releases/1.0.x` branch, then publish 1.0.1 and 1.1.1.

/cc @benvinegar