### PR TITLE
Pass kwargs into shouldSendCallback() as param

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -182,7 +182,7 @@ extend(Raven.prototype, {
 
     var shouldSend = true;
     if (!this._enabled) shouldSend = false;
-    if (this.shouldSendCallback && !this.shouldSendCallback()) shouldSend = false;
+    if (this.shouldSendCallback && !this.shouldSendCallback(kwargs)) shouldSend = false;
 
     if (shouldSend) {
       this.send(kwargs, cb);


### PR DESCRIPTION
In the `shouldSendCallback` function, we need the args in order to determine whether we want to send to sentry based on the current data. This is exactly how things work for the JavaScript client version of raven.