### PR TITLE
Add alert about node vs raven-js when it seems like a browser env

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -23,6 +23,11 @@ nodeUtil.inherits(Raven, events.EventEmitter);
 
 extend(Raven.prototype, {
   config: function config(dsn, options) {
+    // We get lots of users using raven-node when they want raven-js, hence this warning if it seems like a browser
+    if (typeof window !== 'undefined' && typeof document !== 'undefined' && typeof navigator !== 'undefined') {
+      utils.consoleAlert('This looks like a browser environment; are you sure you don\'t want Raven.js for browser JavaScript? https://sentry.io/for/javascript');
+    }
+
     if (arguments.length === 0) {
       // no arguments, use default from environment
       dsn = process.env.SENTRY_DSN;


### PR DESCRIPTION
As per comment [here](https://github.com/getsentry/raven-node/issues/254#issuecomment-281555668). I do this check in `config` so that a user can do `Raven.disableConsoleAlerts()` before `Raven.config` to avoid seeing this alert.

/cc @benvinegar - does this seem like a reasonable message and condition for "seems like a browser?"