### PR TITLE
execute .install() cb even when dsn is not supplied

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -194,6 +194,7 @@ extend(Raven.prototype, {
     } else {
       // wish there was a good way to communicate to cb why we didn't send; worth considering cb api change?
       // avoiding setImmediate here because node 0.8
+      this.emit('skipped', eventId);
       cb && setTimeout(function () {
         cb(null, eventId);
       }, 0);
@@ -505,14 +506,21 @@ function registerExceptionHandler(client, cb) {
         cb(false, err);
       };
 
+      var onSkipped = function onSkipped() {
+        called = false;
+        cb(false, err);
+      };
+
       if (called) {
         client.removeListener('logged', onLogged);
         client.removeListener('error', onError);
+        client.removeListener('skipped', onSkipped);
         return cb(false, err);
       }
 
       client.once('logged', onLogged);
       client.once('error', onError);
+      client.once('skipped', onSkipped);
 
       called = true;
     }


### PR DESCRIPTION
When installing global exception handler and disabling sending the uncaught exception handler is not called. For example:

```
// pass null to config() to disable reporting (for local development)
const ravenClient = Raven.config(null).install(function(logged, err) {
  log.error('process is terminating due to uncaught exception', err);
  process.exit(1);
});
```

This pull request causes the install callback to be populated with the values `(false, err)` when sentry reporting is disabled and a global exception is encountered.