### PR TITLE
Fix autoBreadcrumb http instrumentation memory leak

### DIFF
--- a/lib/breadcrumbs.js
+++ b/lib/breadcrumbs.js
@@ -59,43 +59,31 @@ var wrappers = {
       // possibility: capture one breadcrumb for "req sent" and one for "res recvd"
       // seems excessive but solves the problem and *is* strictly more information
       // could be useful for weird response sequencing bug scenarios
-      var self = this;
-      OrigClientRequest.call(self, options, cb);
+      OrigClientRequest.call(this, options, cb);
 
-      // We could just always grab these from self.agent, self.method, self._headers, self.path, etc
+      // We could just always reconstruct this from this.agent, this._headers, this.path, etc
       // but certain other http-instrumenting libraries (like nock, which we use for tests) fail to
       // maintain the guarantee that after calling OrigClientRequest, those fields will be populated
-      var url, method;
       if (typeof options === 'string') {
-        url = options;
-        method = 'GET';
+        this.__ravenBreadcrumbUrl = options;
       } else {
-        url = (options.protocol || '') + '//' +
+        this.__ravenBreadcrumbUrl = (options.protocol || '') + '//' +
               (options.hostname || options.host || '') +
               (options.path || '/');
-        method = options.method || 'GET';
       }
-
-      this.__ravenBreadcrumbContext = {
-        url: url,
-        method: method
-      };
     };
     util.inherits(ClientRequest, OrigClientRequest);
 
     fill(ClientRequest.prototype, 'emit', function (origEmit) {
       return function (evt, maybeResp) {
-        if (evt === 'response' && this.__ravenBreadcrumbContext) {
-          console.dir(this);
-          var url = this.__ravenBreadcrumbContext.url;
-          var method = this.__ravenBreadcrumbContext.method;
-          if (!Raven.dsn || url.indexOf(Raven.dsn.host) === -1) {
+        if (evt === 'response' && this.__ravenBreadcrumbUrl) {
+          if (!Raven.dsn || this.__ravenBreadcrumbUrl.indexOf(Raven.dsn.host) === -1) {
             Raven.captureBreadcrumb({
               type: 'http',
               category: 'http',
               data: {
-                method: method,
-                url: url,
+                method: this.method,
+                url: this.__ravenBreadcrumbUrl,
                 status_code: maybeResp.statusCode
               }
             });

--- a/lib/breadcrumbs.js
+++ b/lib/breadcrumbs.js
@@ -76,27 +76,35 @@ var wrappers = {
         method = options.method || 'GET';
       }
 
-      // Don't capture breadcrumb for our own requests
-      if (!Raven.dsn || url.indexOf(Raven.dsn.host) === -1) {
-        fill(self, 'emit', function (origEmit) {
-          return function (evt, maybeResp) {
-            if (evt === 'response') {
-              Raven.captureBreadcrumb({
-                type: 'http',
-                category: 'http',
-                data: {
-                  method: method,
-                  url: url,
-                  status_code: maybeResp.statusCode
-                }
-              });
-            }
-            return origEmit.apply(this, arguments);
-          };
-        }, originals);
-      }
+      this.__ravenBreadcrumbContext = {
+        url: url,
+        method: method
+      };
     };
     util.inherits(ClientRequest, OrigClientRequest);
+
+    fill(ClientRequest.prototype, 'emit', function (origEmit) {
+      return function (evt, maybeResp) {
+        if (evt === 'response' && this.__ravenBreadcrumbContext) {
+          console.dir(this);
+          var url = this.__ravenBreadcrumbContext.url;
+          var method = this.__ravenBreadcrumbContext.method;
+          if (!Raven.dsn || url.indexOf(Raven.dsn.host) === -1) {
+            Raven.captureBreadcrumb({
+              type: 'http',
+              category: 'http',
+              data: {
+                method: method,
+                url: url,
+                status_code: maybeResp.statusCode
+              }
+            });
+          }
+        }
+        return origEmit.apply(this, arguments);
+      };
+    });
+
     fill(http, 'ClientRequest', function () {
       return ClientRequest;
     }, originals);


### PR DESCRIPTION
PR #276/version 1.1.3 introduced a memory leak in our http instrumentation as reported in #295. The core issue was that we were monkeypatching `http.ClientRequest.prototype.emit` during every `ClientRequest` instantiation, instead of just during initial instrumentation, which meant that for each outbound http request made, we kept a bunch of stuff around in a closure.

Users on raven-node 1.1.3 or 1.1.4 with long-running processes that made outbound http requests found their memory usage growing steadily over time.

This PR refactors the `ClientRequest` instrumentation to only monkeypatch `http.ClientRequest.prototype.emit` once during initial Raven setup when we also monkeypatch the constructor. The monkeypatched `emit` method previously found the request url by closure reference, but now the constructor attaches a `__ravenBreadcrumbUrl` property to the request object and `emit` grabs that instead.

I confirmed the issue and fix using [memwatch-next](https://www.npmjs.com/package/memwatch-next) (plus express, some outbound requesting, and some apachebenching) and have ideas for how to use that to automate some "did we intro a memory leak" sanity testing, but that can come later. That effort will have to test multiple different possible causes; the manual memory load test in https://github.com/getsentry/raven-node/blob/master/test/manual/context-memory.js would not have caught this because it only exercises contexts, not each of the different autoBreadcrumb instrumentation options.

This should fix #295. As soon as this merges I'll publish a new version.

/cc @benvinegar @MaxBittker @maxcountryman