### PR TITLE
Properly surfacing errors to preserve process exit conditions

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -107,6 +107,20 @@ Those configuration options are documented below:
             sampleRate: 0.5 // send 50% of events, drop the other half
         }
 
+.. describe:: sendTimeout
+
+    The time to wait to connect to the server or receive a response when capturing an exception, in seconds.
+
+    If it takes longer, the transport considers it a failed request and will pass back a timeout error.
+
+    Defaults to 1 second.
+
+    .. code-block:: javascript
+
+        {
+            sendTimeout: 5 // wait 5 seconds before considering the capture to have failed
+        }
+
 .. describe:: dataCallback
 
     A function that allows mutation of the data payload right before being

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -113,7 +113,7 @@ Those configuration options are documented below:
 
     If it takes longer, the transport considers it a failed request and will pass back a timeout error.
 
-    Defaults to 1 second.
+    Defaults to 1 second. Make it longer if you run into timeout problems when sending exceptions to Sentry.
 
     .. code-block:: javascript
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -271,20 +271,20 @@ Global Fatal Error Handler
 --------------------------
 
 The ``install`` method sets up a global listener for uncaught exceptions, and ``context`` and ``wrap`` can catch exceptions as well.
-These are situations where Raven catches what would otherwise be a fatal process-ending exception, and we generally shouldn't keep our
-program running after such events (see `Node docs <http://nodejs.org/api/process.html#process_event_uncaughtexception>`_),
-so Raven has a concept of a "fatal error handler". When Raven catches what would otherwise be a fatal process-ending exception, we
-capture it and then call the fatal error handler.
+These are situations where Raven catches what would otherwise be a fatal process-ending exception; a process should generally not
+continue to run after uncaught exceptions and similar such events (see `Node docs <http://nodejs.org/api/process.html#process_event_uncaughtexception>`_),
+so Raven has a concept of a "fatal error handler". When Raven catches what would otherwise be a fatal process-ending exception,
+it captures the exception and then calls the fatal error handler.
 
-By default, we make the fatal error handler print the error and then exit the process. If you want to do your own clean-up,
+By default, the fatal error handler prints the error and then exits the process. If you want to do your own clean-up,
 pre-exit logging, or other shutdown procedures, you can provide your own fatal error handler as a parameter to ``install()``.
 
 The fatal error hander callback will be the last thing called before the process should shut down.
 It can do anything necessary, including asynchronous operations, to make a best effort to clean up and shut down the process, but it should
-not throw, and it absolutely must not allow the process to keep running indefinitely.
+not throw, and it absolutely must not allow the process to keep running indefinitely. This means it should probably make an explicit ``process.exit()`` call.
 
 After catching a fatal exception, Raven will first attempt to send it to Sentry before it calls the fatal exception handler.
-If sending fails, a ``sendErr`` will be passed, and otherwise the ``eventId`` will be provided. In either case, the fatal exception
+If sending fails, a ``sendErr`` error object will be passed, and otherwise the ``eventId`` will be provided. In either case, the error object 
 resulting in the shutdown is passed as the first parameter.
 
 .. code-block:: javascript

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -271,19 +271,19 @@ Global Fatal Error Handler
 --------------------------
 
 The ``install`` method sets up a global listener for uncaught exceptions, and ``context`` and ``wrap`` can catch exceptions as well.
-These are situations where Raven catches what would otherwise be a fatal process-ending exception; a process should generally not
-continue to run after uncaught exceptions and similar such events (see `Node docs <http://nodejs.org/api/process.html#process_event_uncaughtexception>`_),
-so Raven has a concept of a "fatal error handler". When Raven catches what would otherwise be a fatal process-ending exception,
-it captures the exception and then calls the fatal error handler.
+These are situations where Raven catches what would otherwise be a fatal process-ending exception. A process should generally not
+continue to run after such events occur, (see `Node docs <http://nodejs.org/api/process.html#process_event_uncaughtexception>`_),
+so Raven has a concept of a "fatal error handler". When Raven catches an otherwise-fatal exception, it will capture the exception
+(send it to Sentry) and then call the fatal error handler.
 
 By default, the fatal error handler prints the error and then exits the process. If you want to do your own clean-up,
-pre-exit logging, or other shutdown procedures, you can provide your own fatal error handler as a parameter to ``install()``.
+pre-exit logging, or other shutdown procedures, you can provide your own fatal error handler as an argument to ``install()``.
 
-The fatal error hander callback will be the last thing called before the process should shut down.
+The fatal error handler callback will be the last thing called before the process should shut down.
 It can do anything necessary, including asynchronous operations, to make a best effort to clean up and shut down the process, but it should
 not throw, and it absolutely must not allow the process to keep running indefinitely. This means it should probably make an explicit ``process.exit()`` call.
 
-After catching a fatal exception, Raven will first attempt to send it to Sentry before it calls the fatal exception handler.
+After catching a fatal exception, Raven will make a best-effort attempt to send it to Sentry before it calls the fatal exception handler.
 If sending fails, a ``sendErr`` error object will be passed, and otherwise the ``eventId`` will be provided. In either case, the error object 
 resulting in the shutdown is passed as the first parameter.
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -106,6 +106,14 @@ extend(Raven.prototype, {
     return this;
   },
 
+  setOnFatalErrorCallback: function (cb) {
+    this.onFatalError = cb;
+    // ensure that we use this handler
+    // - after uncaughtExceptions
+    // - after domain context captures
+    registerExceptionHandler(this, cb);
+  },
+
   install: function install(opts, cb) {
     if (this.installed) return this;
 
@@ -113,10 +121,13 @@ extend(Raven.prototype, {
       cb = opts;
     }
 
-    registerExceptionHandler(this, cb);
-    if (this.captureUnhandledRejections) {
-      registerRejectionHandler(this, cb);
+    if (typeof cb !== 'function') {
+      cb = function (err) {
+        console.error(err);
+        process.exit(1);
+      };
     }
+    this.setOnFatalErrorCallback(cb);
 
     for (var key in this.autoBreadcrumbs) {
       if (this.autoBreadcrumbs.hasOwnProperty(key)) {
@@ -288,7 +299,10 @@ extend(Raven.prototype, {
     var self = this;
     if (typeof onErr !== 'function') {
       onErr = function (err) {
-        self.captureException(err);
+
+        self.captureException(err, function (sendErr) {
+          self.onFatalError(err);
+        });
       };
     }
 
@@ -456,11 +470,6 @@ extend(Raven.prototype, {
     utils.consoleAlertOnce('captureQuery has been deprecated and will be removed in v2.0');
     return this;
   },
-  patchGlobal: function (cb) {
-    utils.consoleAlertOnce('patchGlobal has been deprecated and will be removed in v2.0; use install instead');
-    registerExceptionHandler(this, cb);
-    return this;
-  },
   setUserContext: function setUserContext() {
     utils.consoleAlertOnce('setUserContext has been deprecated and will be removed in v2.0; use setContext instead');
     return this;
@@ -488,40 +497,58 @@ nodeUtil.inherits(Client, Raven);
 // todo these extra export props are sort of an adhoc mess, better way to manage?
 var defaultInstance = new Raven();
 defaultInstance.Client = Client;
-defaultInstance.patchGlobal = patchGlobal;
 defaultInstance.version = require('../package.json').version;
 defaultInstance.disableConsoleAlerts = utils.disableConsoleAlerts;
 
 module.exports = defaultInstance;
 
 function registerExceptionHandler(client, cb) {
-  var called = false;
+  // old cb sig: cb(didSend, errCaptured)
+  // now there is a cb 100%, no more if (cb)
+  var calledUncaughtHandler = false;
   process.on('uncaughtException', function (err) {
-    if (cb) { // bind event listeners only if a callback was supplied
-      var onLogged = function onLogged() {
-        called = false;
-        cb(true, err);
-      };
+    if (!calledUncaughtHandler) {
+      // this might be overly careful here - need to avoid getting messed up by recursion
+      calledUncaughtHandler = true;
+      var eventId = client.captureException(err, function (sendErr, eventId) {
+        try {
+          client.onFatalError(err);
+        } catch (e) {
+          // no-op just avoid inf loop...
+        }
+        // consider signature like client.onFatalError(err, sendErr, eventId);
+      });
 
-      var onError = function onError() {
-        called = false;
-        cb(false, err);
-      };
-
-      if (called) {
-        client.removeListener('logged', onLogged);
-        client.removeListener('error', onError);
-        return cb(false, err);
-      }
-
-      client.once('logged', onLogged);
-      client.once('error', onError);
-
-      called = true;
+      // should we return/print anything or just leave it up to onFatalError to do what it wants
+      utils.consoleAlert('uncaughtException:' + eventId);
     }
+    // otherwise no-op? now we only do anything on first uncaughtException...can we at least try to capture
 
-    var eventId = client.captureException(err);
-    return utils.consoleAlert('uncaughtException: ' + eventId);
+    // if (cb) { // bind event listeners only if a callback was supplied
+    //   var onLogged = function onLogged() {
+    //     called = false;
+    //     cb(true, err);
+    //   };
+
+    //   var onError = function onError() {
+    //     called = false;
+    //     cb(false, err);
+    //   };
+
+    //   if (called) {
+    //     client.removeListener('logged', onLogged);
+    //     client.removeListener('error', onError);
+    //     return cb(false, err);
+    //   }
+
+    //   client.once('logged', onLogged);
+    //   client.once('error', onError);
+
+    //   called = true;
+    // }
+
+    // var eventId = client.captureException(err);
+    // return utils.consoleAlert('uncaughtException: ' + eventId);
   });
 }
 
@@ -532,19 +559,4 @@ function registerRejectionHandler(client, cb) {
     });
     return utils.consoleAlert('unhandledRejection: ' + eventId);
   });
-}
-
-function patchGlobal(client, cb) {
-  // handle when the first argument is the callback, with no client specified
-  if (typeof client === 'function') {
-    cb = client;
-    client = new Client();
-    // first argument is a string DSN
-  } else if (typeof client === 'string') {
-    client = new Client(client);
-  }
-  // at the end, if we still don't have a Client, let's make one!
-  !(client instanceof Raven) && (client = new Client());
-
-  registerExceptionHandler(client, cb);
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -99,6 +99,11 @@ extend(Raven.prototype, {
       globalContext.extra = options.extra;
     }
 
+    this.onFatalError = this.defaultOnFatalError = function (err, sendErr, eventId) {
+      console.error(err.stack);
+      process.exit(1);
+    };
+
     this.on('error', function (err) {
       utils.consoleAlert('failed to send exception to sentry: ' + err.message);
     });
@@ -106,28 +111,24 @@ extend(Raven.prototype, {
     return this;
   },
 
-  setOnFatalErrorCallback: function (cb) {
-    this.onFatalError = cb;
-    // ensure that we use this handler
-    // - after uncaughtExceptions
-    // - after domain context captures
-    registerExceptionHandler(this, cb);
-  },
-
-  install: function install(opts, cb) {
+  install: function install(cb) {
     if (this.installed) return this;
 
-    if (typeof opts === 'function') {
-      cb = opts;
+    if (typeof cb === 'function') {
+      this.onFatalError = cb;
     }
 
-    if (typeof cb !== 'function') {
-      cb = function (err) {
-        console.error(err);
-        process.exit(1);
-      };
+    process.on('uncaughtException', this.makeErrorHandler());
+
+    if (this.captureUnhandledRejections) {
+      var self = this;
+      process.on('unhandledRejection', function (reason) {
+        var eventId = self.captureException(reason, function (sendErr) {
+          cb && cb(!sendErr, reason);
+        });
+        return utils.consoleAlert('unhandledRejection: ' + eventId);
+      });
     }
-    this.setOnFatalErrorCallback(cb);
 
     for (var key in this.autoBreadcrumbs) {
       if (this.autoBreadcrumbs.hasOwnProperty(key)) {
@@ -152,6 +153,30 @@ extend(Raven.prototype, {
     this.installed = false;
 
     return this;
+  },
+
+  makeErrorHandler: function () {
+    var self = this;
+    var calledUncaughtHandler = false;
+    var calledFatalError = false;
+    var firstError;
+    return function (err) {
+      if (!calledUncaughtHandler) {
+        firstError = err;
+        calledUncaughtHandler = true;
+        self.captureException(err, function (sendErr, eventId) {
+          calledFatalError = true;
+          self.onFatalError(err, sendErr, eventId);
+        });
+      } else if (!calledFatalError) {
+        self.onFatalError(firstError, err);
+      } else {
+        // we hit an error *after* calling onFatalError - pretty fucked
+        // maybe this should just be like "default onFatalError"
+        console.error(err);
+        process.exit(1);
+      }
+    };
   },
 
   generateEventId: function generateEventId() {
@@ -501,62 +526,3 @@ defaultInstance.version = require('../package.json').version;
 defaultInstance.disableConsoleAlerts = utils.disableConsoleAlerts;
 
 module.exports = defaultInstance;
-
-function registerExceptionHandler(client, cb) {
-  // old cb sig: cb(didSend, errCaptured)
-  // now there is a cb 100%, no more if (cb)
-  var calledUncaughtHandler = false;
-  process.on('uncaughtException', function (err) {
-    if (!calledUncaughtHandler) {
-      // this might be overly careful here - need to avoid getting messed up by recursion
-      calledUncaughtHandler = true;
-      var eventId = client.captureException(err, function (sendErr, eventId) {
-        try {
-          client.onFatalError(err);
-        } catch (e) {
-          // no-op just avoid inf loop...
-        }
-        // consider signature like client.onFatalError(err, sendErr, eventId);
-      });
-
-      // should we return/print anything or just leave it up to onFatalError to do what it wants
-      utils.consoleAlert('uncaughtException:' + eventId);
-    }
-    // otherwise no-op? now we only do anything on first uncaughtException...can we at least try to capture
-
-    // if (cb) { // bind event listeners only if a callback was supplied
-    //   var onLogged = function onLogged() {
-    //     called = false;
-    //     cb(true, err);
-    //   };
-
-    //   var onError = function onError() {
-    //     called = false;
-    //     cb(false, err);
-    //   };
-
-    //   if (called) {
-    //     client.removeListener('logged', onLogged);
-    //     client.removeListener('error', onError);
-    //     return cb(false, err);
-    //   }
-
-    //   client.once('logged', onLogged);
-    //   client.once('error', onError);
-
-    //   called = true;
-    // }
-
-    // var eventId = client.captureException(err);
-    // return utils.consoleAlert('uncaughtException: ' + eventId);
-  });
-}
-
-function registerRejectionHandler(client, cb) {
-  process.on('unhandledRejection', function (reason) {
-    var eventId = client.captureException(reason, function (sendErr) {
-      cb && cb(!sendErr, reason);
-    });
-    return utils.consoleAlert('unhandledRejection: ' + eventId);
-  });
-}

--- a/lib/client.js
+++ b/lib/client.js
@@ -101,7 +101,7 @@ extend(Raven.prototype, {
     }
 
     this.onFatalError = this.defaultOnFatalError = function (err, sendErr, eventId) {
-      console.error(err.stack);
+      console.error(err && err.stack ? err.stack : err);
       process.exit(1);
     };
     this.uncaughtErrorHandler = this.makeErrorHandler();

--- a/lib/client.js
+++ b/lib/client.js
@@ -104,6 +104,7 @@ extend(Raven.prototype, {
       console.error(err.stack);
       process.exit(1);
     };
+    this.uncaughtErrorHandler = this.makeErrorHandler();
 
     this.on('error', function (err) {
       utils.consoleAlert('failed to send exception to sentry: ' + err.message);
@@ -119,7 +120,7 @@ extend(Raven.prototype, {
       this.onFatalError = cb;
     }
 
-    process.on('uncaughtException', this.makeErrorHandler());
+    process.on('uncaughtException', this.uncaughtErrorHandler);
 
     if (this.captureUnhandledRejections) {
       var self = this;
@@ -157,22 +158,50 @@ extend(Raven.prototype, {
 
   makeErrorHandler: function () {
     var self = this;
-    var calledUncaughtHandler = false;
+    var caughtFirstError = false;
+    var caughtSecondError = false;
     var calledFatalError = false;
     var firstError;
     return function (err) {
-      if (!calledUncaughtHandler) {
+      if (!caughtFirstError) {
+        // this is the first uncaught error and the ultimate reason for shutting down
+        // we want to do absolutely everything possible to ensure it gets captured
+        // also we want to make sure we don't go recursion crazy if more errors happen after this one
         firstError = err;
-        calledUncaughtHandler = true;
+        caughtFirstError = true;
         self.captureException(err, function (sendErr, eventId) {
-          calledFatalError = true;
-          self.onFatalError(err, sendErr, eventId);
+          if (!calledFatalError) {
+            calledFatalError = true;
+            self.onFatalError(err, sendErr, eventId);
+          }
         });
-      } else if (!calledFatalError) {
-        calledFatalError = true;
-        self.onFatalError(firstError, err);
-      } else {
-        // we hit an error *after* calling onFatalError - pretty boned at this point
+      } else if (!caughtSecondError) {
+        // two cases for how we can hit this branch:
+        //   - capturing of first error blew up and we just caught the exception from that
+        //     - quit trying to capture, proceed with shutdown
+        //   - a second independent error happened while waiting for first error to capture
+        //     - want to avoid causing premature shutdown before first error capture finishes
+        // it's hard to immediately tell case 1 from case 2 without doing some fancy/questionable domain stuff
+        // so let's instead just delay a bit before we proceed with our action here
+        // in case 1, we just wait a bit unnecessarily but ultimately do the same thing
+        // in case 2, the delay hopefully made us wait long enough for the capture to finish
+        // two potential nonideal outcomes:
+        //   nonideal case 1: capturing fails fast, we sit around for a few seconds unnecessarily before proceeding correctly by calling onFatalError
+        //   nonideal case 2: case 2 happens, 1st error is captured but slowly, timeout completes before capture and we treat second error as the sendErr of (nonexistent) failure from trying to capture first error
+        // note that after hitting this branch, we might catch more errors where (caughtSecondError && !calledFatalError)
+        //   we ignore them - they don't matter to us, we're just waiting for the second error timeout to finish
+        caughtSecondError = true;
+        setTimeout(function () {
+          if (!calledFatalError) {
+            // it was probably case 1, let's treat err as the sendErr and call onFatalError
+            calledFatalError = true;
+            self.onFatalError(firstError, err);
+          } else {
+            // it was probably case 2, our first error finished capturing while we waited, cool, do nothing
+          }
+        }, (self.sendTimeout + 1) * 1000); // capturing could take at least sendTimeout to fail, plus an arbitrary second for how long it takes to collect surrounding source etc
+      } else if (calledFatalError) {
+        // we hit an error *after* calling onFatalError - pretty boned at this point, just shut it down
         self.consoleAlert('uncaught exception after calling fatal error shutdown callback - this is bad! forcing shutdown');
         self.defaultOnFatalError(err);
       }
@@ -321,7 +350,7 @@ extend(Raven.prototype, {
     // todo: better property name than sentryContext, maybe __raven__ or sth?
     wrapDomain.sentryContext = options;
 
-    wrapDomain.on('error', this.makeErrorHandler());
+    wrapDomain.on('error', this.uncaughtErrorHandler);
     var wrapped = wrapDomain.bind(func);
 
     for (var property in func) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -45,6 +45,7 @@ extend(Raven.prototype, {
     this.name = options.name || process.env.SENTRY_NAME || require('os').hostname();
     this.root = options.root || process.cwd();
     this.transport = options.transport || transports[this.dsn.protocol];
+    this.sendTimeout = options.sendTimeout || 1;
     this.release = options.release || process.env.SENTRY_RELEASE || '';
     this.environment = options.environment || process.env.SENTRY_ENVIRONMENT || '';
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -169,12 +169,12 @@ extend(Raven.prototype, {
           self.onFatalError(err, sendErr, eventId);
         });
       } else if (!calledFatalError) {
+        calledFatalError = true;
         self.onFatalError(firstError, err);
       } else {
-        // we hit an error *after* calling onFatalError - pretty fucked
-        // maybe this should just be like "default onFatalError"
-        console.error(err);
-        process.exit(1);
+        // we hit an error *after* calling onFatalError - pretty boned at this point
+        self.consoleAlert('uncaught exception after calling fatal error shutdown callback - this is bad! forcing shutdown');
+        self.defaultOnFatalError(err);
       }
     };
   },

--- a/lib/client.js
+++ b/lib/client.js
@@ -299,7 +299,7 @@ extend(Raven.prototype, {
    * We could consider getting rid of it and just duplicating the domain
    * instantiation etc logic in the requestHandler middleware
    */
-  context: function (ctx, func, onErr) {
+  context: function (ctx, func) {
     if (!func && typeof ctx === 'function') {
       func = ctx;
       ctx = {};
@@ -308,10 +308,10 @@ extend(Raven.prototype, {
     // todo/note: raven-js takes an args param to do apply(this, args)
     // i don't think it's correct/necessary to bind this to the wrap call
     // and i don't know if we need to support the args param; it's undocumented
-    return this.wrap(ctx, func, onErr).apply(null);
+    return this.wrap(ctx, func).apply(null);
   },
 
-  wrap: function (options, func, onErr) {
+  wrap: function (options, func) {
     if (!func && typeof options === 'function') {
       func = options;
       options = {};
@@ -321,17 +321,7 @@ extend(Raven.prototype, {
     // todo: better property name than sentryContext, maybe __raven__ or sth?
     wrapDomain.sentryContext = options;
 
-    var self = this;
-    if (typeof onErr !== 'function') {
-      onErr = function (err) {
-
-        self.captureException(err, function (sendErr) {
-          self.onFatalError(err);
-        });
-      };
-    }
-
-    wrapDomain.on('error', onErr);
+    wrapDomain.on('error', this.makeErrorHandler());
     var wrapped = wrapDomain.bind(func);
 
     for (var property in func) {
@@ -443,7 +433,7 @@ extend(Raven.prototype, {
         domain.active.add(req);
         domain.active.add(res);
         next();
-      }, next);
+      });
     };
   },
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -124,10 +124,9 @@ extend(Raven.prototype, {
     if (this.captureUnhandledRejections) {
       var self = this;
       process.on('unhandledRejection', function (reason) {
-        var eventId = self.captureException(reason, function (sendErr) {
-          cb && cb(!sendErr, reason);
+        self.captureException(reason, function (sendErr, eventId) {
+          if (!sendErr) utils.consoleAlert('unhandledRejection captured: ' + eventId);
         });
-        return utils.consoleAlert('unhandledRejection: ' + eventId);
       });
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -175,6 +175,10 @@ extend(Raven.prototype, {
             self.onFatalError(err, sendErr, eventId);
           }
         });
+      } else if (calledFatalError) {
+        // we hit an error *after* calling onFatalError - pretty boned at this point, just shut it down
+        utils.consoleAlert('uncaught exception after calling fatal error shutdown callback - this is bad! forcing shutdown');
+        self.defaultOnFatalError(err);
       } else if (!caughtSecondError) {
         // two cases for how we can hit this branch:
         //   - capturing of first error blew up and we just caught the exception from that
@@ -200,10 +204,6 @@ extend(Raven.prototype, {
             // it was probably case 2, our first error finished capturing while we waited, cool, do nothing
           }
         }, (self.sendTimeout + 1) * 1000); // capturing could take at least sendTimeout to fail, plus an arbitrary second for how long it takes to collect surrounding source etc
-      } else if (calledFatalError) {
-        // we hit an error *after* calling onFatalError - pretty boned at this point, just shut it down
-        self.consoleAlert('uncaught exception after calling fatal error shutdown callback - this is bad! forcing shutdown');
-        self.defaultOnFatalError(err);
       }
     };
   },

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -2,11 +2,13 @@
 
 var events = require('events');
 var util = require('util');
+var timeoutReq = require('timed-out');
+
+var http = require('http');
+var https = require('https');
 
 function Transport() {}
 util.inherits(Transport, events.EventEmitter);
-
-var http = require('http');
 
 function HTTPTransport(options) {
   this.defaultPort = 80;
@@ -28,6 +30,7 @@ HTTPTransport.prototype.send = function (client, message, headers, eventId, cb) 
       options[key] = this.options[key];
     }
   }
+
   var req = this.transport.request(options, function (res) {
     res.setEncoding('utf8');
     if (res.statusCode >= 200 && res.statusCode < 300) {
@@ -51,6 +54,10 @@ HTTPTransport.prototype.send = function (client, message, headers, eventId, cb) 
     res.on('end', noop);
   });
 
+  if (typeof client.dsn.timeout === 'number') {
+    timeoutReq(req, client.dsn.timeout * 1000);
+  }
+
   var cbFired = false;
   req.on('error', function (e) {
     client.emit('error', e);
@@ -61,8 +68,6 @@ HTTPTransport.prototype.send = function (client, message, headers, eventId, cb) 
   });
   req.end(message);
 };
-
-var https = require('https');
 
 function HTTPSTransport(options) {
   this.defaultPort = 443;

--- a/lib/transports.js
+++ b/lib/transports.js
@@ -54,9 +54,7 @@ HTTPTransport.prototype.send = function (client, message, headers, eventId, cb) 
     res.on('end', noop);
   });
 
-  if (typeof client.dsn.timeout === 'number') {
-    timeoutReq(req, client.dsn.timeout * 1000);
-  }
+  timeoutReq(req, client.sendTimeout * 1000);
 
   var cbFired = false;
   req.on('error', function (e) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,9 +69,6 @@ module.exports.parseDSN = function parseDSN(dsn) {
           host: parsed.host.split(':')[0]
         };
 
-    var timeout = qs.parse(parsed.query).timeout;
-    response.timeout = typeof timeout === 'string' ? +timeout : 1;
-
     if (~response.protocol.indexOf('+')) {
       response.protocol = response.protocol.split('+')[1];
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,6 @@
 
 var fs = require('fs');
 var url = require('url');
-var qs = require('querystring');
 var transports = require('./transports');
 var path = require('path');
 var lsmod = require('lsmod');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var url = require('url');
+var qs = require('querystring');
 var transports = require('./transports');
 var path = require('path');
 var lsmod = require('lsmod');
@@ -67,6 +68,9 @@ module.exports.parseDSN = function parseDSN(dsn) {
           private_key: parsed.auth.split(':')[1],
           host: parsed.host.split(':')[0]
         };
+
+    var timeout = qs.parse(parsed.query).timeout;
+    response.timeout = typeof timeout === 'string' ? +timeout : 1;
 
     if (~response.protocol.indexOf('+')) {
       response.protocol = response.protocol.split('+')[1];

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "json-stringify-safe": "5.0.1",
     "lsmod": "1.0.0",
     "uuid": "3.0.0",
-    "stack-trace": "0.0.9"
+    "stack-trace": "0.0.9",
+    "timed-out": "4.0.1"
   },
   "devDependencies": {
     "coffee-script": "~1.10.0",

--- a/test/exit/capture.js
+++ b/test/exit/capture.js
@@ -1,0 +1,20 @@
+'use strict';
+var Raven = require('../../');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+var nock = require('nock');
+var scope = nock('https://app.getsentry.com')
+  .filteringRequestBody(/.*/, '*')
+  .post('/api/269/store/', '*')
+  .reply(200, 'OK');
+
+Raven.config(dsn).install();
+
+process.on('exit', function () {
+  scope.done();
+  console.log('exit test assertions complete');
+});
+
+setImmediate(function () {
+  throw new Error('derp');
+});

--- a/test/exit/capture_callback.js
+++ b/test/exit/capture_callback.js
@@ -1,0 +1,23 @@
+'use strict';
+var Raven = require('../../');
+var assert = require('assert');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+var nock = require('nock');
+var scope = nock('https://app.getsentry.com')
+  .filteringRequestBody(/.*/, '*')
+  .post('/api/269/store/', '*')
+  .reply(200, 'OK');
+
+Raven.config(dsn).install(function (err, sendErr, eventId) {
+  scope.done();
+  assert.equal(sendErr, null);
+  assert.ok(err instanceof Error);
+  assert.equal(err.message, 'derp');
+  console.log('exit test assertions complete');
+  process.exit(20);
+});
+
+setImmediate(function () {
+  throw new Error('derp');
+});

--- a/test/exit/capture_with_second_domain_error.js
+++ b/test/exit/capture_with_second_domain_error.js
@@ -1,0 +1,36 @@
+'use strict';
+var Raven = require('../../');
+var assert = require('assert');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+var nock = require('nock');
+var scope = nock('https://app.getsentry.com')
+  .filteringRequestBody(/.*/, '*')
+  .post('/api/269/store/', '*')
+  .reply(200, 'OK');
+
+Raven.config(dsn).install();
+
+var uncaughts = 0;
+process.on('uncaughtException', function () {
+  uncaughts++;
+});
+
+process.on('exit', function () {
+  scope.done();
+  assert.equal(uncaughts, 2);
+  console.log('exit test assertions complete');
+});
+
+setImmediate(function () {
+  throw new Error('derp');
+});
+
+Raven.context(function () {
+  process.domain.on('error', function () {
+    uncaughts++;
+  });
+  setImmediate(function () {
+    throw new Error('herp');
+  });
+});

--- a/test/exit/capture_with_second_error.js
+++ b/test/exit/capture_with_second_error.js
@@ -1,0 +1,30 @@
+'use strict';
+var Raven = require('../../');
+var assert = require('assert');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+var nock = require('nock');
+var scope = nock('https://app.getsentry.com')
+  .filteringRequestBody(/.*/, '*')
+  .post('/api/269/store/', '*')
+  .reply(200, 'OK');
+
+Raven.config(dsn).install();
+
+var uncaughts = 0;
+process.on('uncaughtException', function () {
+  uncaughts++;
+});
+
+process.on('exit', function () {
+  scope.done();
+  assert.equal(uncaughts, 2);
+  console.log('exit test assertions complete');
+});
+
+setImmediate(function () {
+  setImmediate(function () {
+    throw new Error('herp');
+  });
+  throw new Error('derp');
+});

--- a/test/exit/domain_capture.js
+++ b/test/exit/domain_capture.js
@@ -1,0 +1,22 @@
+'use strict';
+var Raven = require('../../');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+var nock = require('nock');
+var scope = nock('https://app.getsentry.com')
+  .filteringRequestBody(/.*/, '*')
+  .post('/api/269/store/', '*')
+  .reply(200, 'OK');
+
+Raven.config(dsn).install();
+
+process.on('exit', function () {
+  scope.done();
+  console.log('exit test assertions complete');
+});
+
+Raven.context(function () {
+  setImmediate(function () {
+    throw new Error('derp');
+  });
+});

--- a/test/exit/domain_capture_callback.js
+++ b/test/exit/domain_capture_callback.js
@@ -1,0 +1,25 @@
+'use strict';
+var Raven = require('../../');
+var assert = require('assert');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+var nock = require('nock');
+var scope = nock('https://app.getsentry.com')
+  .filteringRequestBody(/.*/, '*')
+  .post('/api/269/store/', '*')
+  .reply(200, 'OK');
+
+Raven.config(dsn).install(function (err, sendErr, eventId) {
+  scope.done();
+  assert.equal(sendErr, null);
+  assert.ok(err instanceof Error);
+  assert.equal(err.message, 'derp');
+  console.log('exit test assertions complete');
+  process.exit(20);
+});
+
+Raven.context(function () {
+  setImmediate(function () {
+    throw new Error('derp');
+  });
+});

--- a/test/exit/domain_capture_with_second_error.js
+++ b/test/exit/domain_capture_with_second_error.js
@@ -1,0 +1,32 @@
+'use strict';
+var Raven = require('../../');
+var assert = require('assert');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+var nock = require('nock');
+var scope = nock('https://app.getsentry.com')
+  .filteringRequestBody(/.*/, '*')
+  .post('/api/269/store/', '*')
+  .reply(200, 'OK');
+
+Raven.config(dsn).install();
+
+var uncaughts = 0;
+
+process.on('exit', function () {
+  scope.done();
+  assert.equal(uncaughts, 2);
+  console.log('exit test assertions complete');
+});
+
+Raven.context(function () {
+  process.domain.on('error', function () {
+    uncaughts++;
+  });
+  setImmediate(function () {
+    setImmediate(function () {
+      throw new Error('herp');
+    });
+    throw new Error('derp');
+  });
+});

--- a/test/exit/domain_throw_on_send.js
+++ b/test/exit/domain_throw_on_send.js
@@ -1,0 +1,23 @@
+'use strict';
+var Raven = require('../../');
+var assert = require('assert');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+Raven.config(dsn).install(function (err, sendErr) {
+  assert.ok(err instanceof Error);
+  assert.ok(sendErr instanceof Error);
+  assert.equal(err.message, 'derp');
+  assert.equal(sendErr.message, 'foo');
+  console.log('exit test assertions complete');
+  process.exit(20);
+});
+
+Raven.transport.send = function () {
+  throw new Error('foo');
+};
+
+Raven.context(function () {
+  setImmediate(function () {
+    throw new Error('derp');
+  });
+});

--- a/test/exit/throw_on_fatal.js
+++ b/test/exit/throw_on_fatal.js
@@ -1,0 +1,25 @@
+'use strict';
+var Raven = require('../../');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+var nock = require('nock');
+var scope = nock('https://app.getsentry.com')
+  .filteringRequestBody(/.*/, '*')
+  .post('/api/269/store/', '*')
+  .reply(200, 'OK');
+
+Raven.disableConsoleAlerts();
+Raven.config(dsn).install(function () {
+  setImmediate(function () {
+    throw new Error('fatal derp');
+  });
+});
+
+process.on('exit', function () {
+  scope.done();
+  console.log('exit test assertions complete');
+});
+
+setImmediate(function () {
+  throw new Error('derp');
+});

--- a/test/exit/throw_on_send.js
+++ b/test/exit/throw_on_send.js
@@ -1,0 +1,19 @@
+'use strict';
+var Raven = require('../../');
+var assert = require('assert');
+var dsn = 'https://public:private@app.getsentry.com/269';
+
+Raven.config(dsn).install(function (err, sendErr) {
+  assert.ok(err instanceof Error);
+  assert.ok(sendErr instanceof Error);
+  assert.equal(err.message, 'derp');
+  assert.equal(sendErr.message, 'foo');
+  console.log('exit test assertions complete');
+  process.exit(20);
+});
+
+Raven.transport.send = function () {
+  throw new Error('foo');
+};
+
+process.emit('uncaughtException', new Error('derp'));

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -408,6 +408,14 @@ describe('raven.Client', function () {
           done();
         });
       });
+
+      it('should catch an uncaughtException and capture it without a second followup domain exception causing premature shutdown', function (done) {
+        child_process.exec('node test/exit/capture_with_second_domain_error.js', function (err, stdout, stderr) {
+          stdout.should.equal(exitStr);
+          stderr.should.startWith('Error: derp');
+          done();
+        });
+      });
     });
   });
 

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -356,7 +356,16 @@ describe('raven.Client', function () {
         });
       });
 
+      it('should catch an uncaughtException and capture it without a second followup exception causing premature shutdown', function (done) {
+        child_process.exec('node test/exit/capture_with_second_error.js', function (err, stdout, stderr) {
+          stdout.should.equal(exitStr);
+          stderr.should.startWith('Error: derp');
+          done();
+        });
+      });
+
       it('should treat an error thrown by captureException from uncaughtException handler as a sending error passed to onFatalError', function (done) {
+        this.timeout(4000);
         child_process.exec('node test/exit/throw_on_send.js', function (err, stdout, stderr) {
           err.code.should.equal(20);
           stdout.should.equal(exitStr);
@@ -382,7 +391,16 @@ describe('raven.Client', function () {
         });
       });
 
+      it('should catch a domain exception and capture it without a second followup exception causing premature shutdown', function (done) {
+        child_process.exec('node test/exit/domain_capture_with_second_error.js', function (err, stdout, stderr) {
+          stdout.should.equal(exitStr);
+          stderr.should.startWith('Error: derp');
+          done();
+        });
+      });
+
       it('should treat an error thrown by captureException from domain exception handler as a sending error passed to onFatalError', function (done) {
+        this.timeout(4000);
         child_process.exec('node test/exit/domain_throw_on_send.js', function (err, stdout, stderr) {
           err.code.should.equal(20);
           stdout.should.equal(exitStr);

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -300,9 +300,16 @@ describe('raven.Client', function () {
       var listeners = process.listeners('unhandledRejection');
       listeners.length.should.equal(0);
 
+      var scope = nock('https://app.getsentry.com')
+        .filteringRequestBody(/.*/, '*')
+        .post('/api/269/store/', '*')
+        .reply(200, 'OK');
+
       client = new raven.Client(dsn, { captureUnhandledRejections: true });
-      client.install(function (sent, reason) {
-        reason.message.should.equal('rejected!');
+      client.install();
+
+      client.on('logged', function () {
+        scope.done();
         done();
       });
 

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -49,7 +49,8 @@ describe('raven.Client', function () {
       host: 'app.getsentry.com',
       path: '/',
       project_id: '269',
-      port: 443
+      port: 443,
+      timeout: 1
     };
     var client = new raven.Client(dsn, {
       name: 'YAY!'
@@ -66,7 +67,8 @@ describe('raven.Client', function () {
       host: 'app.getsentry.com',
       path: '/',
       project_id: '1',
-      port: 443
+      port: 443,
+      timeout: 1
     };
     process.env.SENTRY_DSN = 'https://abc:123@app.getsentry.com/1';
     var client = new raven.Client();
@@ -82,7 +84,8 @@ describe('raven.Client', function () {
       host: 'app.getsentry.com',
       path: '/',
       project_id: '1',
-      port: 443
+      port: 443,
+      timeout: 1
     };
     process.env.SENTRY_DSN = 'https://abc:123@app.getsentry.com/1';
     var client = new raven.Client({
@@ -660,7 +663,8 @@ describe('raven.Client', function () {
       host: 'app.getsentry.com',
       path: '/',
       project_id: '269',
-      port: 443
+      port: 443,
+      timeout: 1
     };
     var dsn = 'heka+https://public:private@app.getsentry.com/269';
     var client = new raven.Client(dsn, {

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -416,6 +416,14 @@ describe('raven.Client', function () {
           done();
         });
       });
+
+      it('should catch an uncaughtException and capture it and failsafe shutdown if onFatalError throws', function (done) {
+        child_process.exec('node test/exit/throw_on_fatal.js', function (err, stdout, stderr) {
+          stdout.should.equal(exitStr);
+          stderr.should.startWith('Error: fatal derp');
+          done();
+        });
+      });
     });
   });
 

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -51,7 +51,6 @@ describe('raven.Client', function () {
       path: '/',
       project_id: '269',
       port: 443,
-      timeout: 1
     };
     var client = new raven.Client(dsn, {
       name: 'YAY!'
@@ -69,7 +68,6 @@ describe('raven.Client', function () {
       path: '/',
       project_id: '1',
       port: 443,
-      timeout: 1
     };
     process.env.SENTRY_DSN = 'https://abc:123@app.getsentry.com/1';
     var client = new raven.Client();
@@ -86,7 +84,6 @@ describe('raven.Client', function () {
       path: '/',
       project_id: '1',
       port: 443,
-      timeout: 1
     };
     process.env.SENTRY_DSN = 'https://abc:123@app.getsentry.com/1';
     var client = new raven.Client({
@@ -337,10 +334,6 @@ describe('raven.Client', function () {
       var exitStr = 'exit test assertions complete\n';
       it('should catch an uncaughtException and capture it before exiting', function (done) {
         child_process.exec('node test/exit/capture.js', function (err, stdout, stderr) {
-          console.log('hey there');
-          console.log(stdout);
-          console.log('that was stdout');
-          console.log(stderr);
           stdout.should.equal(exitStr);
           stderr.should.startWith('Error: derp');
           done();
@@ -658,8 +651,7 @@ describe('raven.Client', function () {
       host: 'app.getsentry.com',
       path: '/',
       project_id: '269',
-      port: 443,
-      timeout: 1
+      port: 443
     };
     var dsn = 'heka+https://public:private@app.getsentry.com/269';
     var client = new raven.Client(dsn, {

--- a/test/raven.utils.js
+++ b/test/raven.utils.js
@@ -14,7 +14,8 @@ describe('raven.utils', function () {
         host: 'app.getsentry.com',
         path: '/',
         project_id: '269',
-        port: 443
+        port: 443,
+        timeout: 1
       };
       dsn.should.eql(expected);
     });
@@ -28,7 +29,8 @@ describe('raven.utils', function () {
         host: 'mysentry.com',
         path: '/some/other/path/',
         project_id: '269',
-        port: 80
+        port: 80,
+        timeout: 1
       };
       dsn.should.eql(expected);
     });
@@ -42,7 +44,23 @@ describe('raven.utils', function () {
         host: 'mysentry.com',
         path: '/some/other/path/',
         project_id: '269',
-        port: 8443
+        port: 8443,
+        timeout: 1
+      };
+      dsn.should.eql(expected);
+    });
+
+    it('should parse DSN with querystring timeout param', function () {
+      var dsn = raven.utils.parseDSN('https://8769c40cf49c4cc58b51fa45d8e2d166:296768aa91084e17b5ac02d3ad5bc7e7@app.getsentry.com/269?timeout=5');
+      var expected = {
+        protocol: 'https',
+        public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
+        private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
+        host: 'app.getsentry.com',
+        path: '/',
+        project_id: '269',
+        port: 443,
+        timeout: 5
       };
       dsn.should.eql(expected);
     });
@@ -67,7 +85,8 @@ describe('raven.utils', function () {
         host: 'mysentry.com',
         path: '/some/other/path/',
         project_id: '269',
-        port: 8443
+        port: 8443,
+        timeout: 1
       };
       dsn.should.eql(expected);
     });

--- a/test/raven.utils.js
+++ b/test/raven.utils.js
@@ -15,7 +15,6 @@ describe('raven.utils', function () {
         path: '/',
         project_id: '269',
         port: 443,
-        timeout: 1
       };
       dsn.should.eql(expected);
     });
@@ -30,7 +29,6 @@ describe('raven.utils', function () {
         path: '/some/other/path/',
         project_id: '269',
         port: 80,
-        timeout: 1
       };
       dsn.should.eql(expected);
     });
@@ -45,22 +43,6 @@ describe('raven.utils', function () {
         path: '/some/other/path/',
         project_id: '269',
         port: 8443,
-        timeout: 1
-      };
-      dsn.should.eql(expected);
-    });
-
-    it('should parse DSN with querystring timeout param', function () {
-      var dsn = raven.utils.parseDSN('https://8769c40cf49c4cc58b51fa45d8e2d166:296768aa91084e17b5ac02d3ad5bc7e7@app.getsentry.com/269?timeout=5');
-      var expected = {
-        protocol: 'https',
-        public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
-        private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
-        host: 'app.getsentry.com',
-        path: '/',
-        project_id: '269',
-        port: 443,
-        timeout: 5
       };
       dsn.should.eql(expected);
     });
@@ -86,7 +68,6 @@ describe('raven.utils', function () {
         path: '/some/other/path/',
         project_id: '269',
         port: 8443,
-        timeout: 1
       };
       dsn.should.eql(expected);
     });


### PR DESCRIPTION
Two parts to this - the timing stuff, and the onFatalError stuff. Still working on the global uncaughtException part of the onFatalError stuff to make sure we capture as much as possible while avoiding recursive cases, but I tried to fill in some comments where the code is still in flux. Then I'm going to finish refactoring a bunch of tests from `patchGlobal` to `install`.

We introduce a dep on [timed-out](https://github.com/floatdrop/timed-out) which I've audited and is basically the "turn connect-timeouts and activity-timeouts into errors" logic ripped out of [request](https://github.com/request/request). This was a necessary prerequisite for us to ensure the onFatalError callback gets called no matter what happens. The timing config part might be redone to use config fields instead of dsn query param.

/cc @benvinegar 