### PR TITLE
Don't include domain prop as extra property on Error objects

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -31,7 +31,7 @@ module.exports.parseError = function parseError(err, kwargs, cb) {
     var extraErrorProps;
     for (var key in err) {
       if (err.hasOwnProperty(key)) {
-        if (key !== 'name' && key !== 'message' && key !== 'stack') {
+        if (key !== 'name' && key !== 'message' && key !== 'stack' && key !== 'domain') {
           extraErrorProps = extraErrorProps || {};
           extraErrorProps[key] = err[key];
         }


### PR DESCRIPTION
An error caught by a domain handler (from `context()` or `requestHandler`) will have a `domain` property. Domains can have references to all kinds of stuff - Express layers, server sockets, who knows what, just depends on what functions ran in the domain - and we don't really get any value from including it as an extra property on error objects like we currently do.

It's potentially confusing, could include random (maybe-sensitive) server state, and is a bunch (sometimes a *whole* bunch) of data for little value.

Previously:
![](http://i.imgur.com/H5PebWP.png)

After:
![](http://i.imgur.com/iaPGekF.png)

/cc @MaxBittker @benvinegar 
