### PR TITLE
Parse req from context, and requestHandler sets req on context

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -228,6 +228,13 @@ extend(Raven.prototype, {
       values: domainContext.breadcrumbs || this._globalContext.breadcrumbs || []
     };
 
+    kwargs.request = extend({}, this._globalContext.request, domainContext.request, kwargs.request);
+    if (Object.keys(kwargs.request).length === 0) {
+      var req = extend({}, this._globalContext.req, domainContext.req, kwargs.req);
+      var parseUser = Object.keys(kwargs.user).length === 0 ? this.parseUser : false;
+      kwargs = extend(kwargs, parsers.parseRequest(req, parseUser));
+    }
+
     kwargs.modules = utils.getModules();
     kwargs.server_name = kwargs.server_name || this.name;
 
@@ -323,11 +330,6 @@ extend(Raven.prototype, {
     return eventId;
   },
 
-  /* The onErr param here is sort of ugly and won't typically be used
-   * but it lets us write the requestHandler middleware in terms of this function.
-   * We could consider getting rid of it and just duplicating the domain
-   * instantiation etc logic in the requestHandler middleware
-   */
   context: function (ctx, func) {
     if (!func && typeof ctx === 'function') {
       func = ctx;
@@ -458,7 +460,7 @@ extend(Raven.prototype, {
   requestHandler: function () {
     var self = this;
     return function (req, res, next) {
-      self.context({}, function () {
+      self.context({ req: req }, function () {
         domain.active.add(req);
         domain.active.add(res);
         next();

--- a/lib/client.js
+++ b/lib/client.js
@@ -228,6 +228,14 @@ extend(Raven.prototype, {
       values: domainContext.breadcrumbs || this._globalContext.breadcrumbs || []
     };
 
+    /*
+      `request` is our specified property name for the http interface: https://docs.sentry.io/clientdev/interfaces/http/
+      `req` is the conventional name for a request object in node/express/etc
+      we want to enable someone to pass a `request` property to kwargs according to http interface
+      but also want to provide convenience for passing a req object and having us parse it out
+      so we only parse a `req` property if the `request` property is absent/empty (and hence we won't clobber)
+      parseUser returns a partial kwargs object with a `request` property and possibly a `user` property
+    */
     kwargs.request = extend({}, this._globalContext.request, domainContext.request, kwargs.request);
     if (Object.keys(kwargs.request).length === 0) {
       var req = extend({}, this._globalContext.req, domainContext.req, kwargs.req);


### PR DESCRIPTION
This basically implements a slightly more thorough version of what I described in [this comment](https://github.com/getsentry/raven-node/issues/82#issuecomment-281935866) in #82, and should also address what #92 and #93 were trying to solve.

Basically you can now do:
```javascript
Raven.setContext({ req: req });
```
and then we'll parse `req` as a node/express/koa request object the same way the `errorHandler` middleware does. We'll do the same for a req passed via kwargs to a captureException call:
```javascript
Raven.captureException(myError, { req: req });
```
and the `requestHandler` middleware now automatically adds `req` to the context (i.e. does this for you).

/cc @MaxBittker @benvinegar 