### PR TITLE
Remove pg instrumentation

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -166,7 +166,6 @@ Those configuration options are documented below:
       autoBreadcrumbs: {
           'console': false,  // console logging
           'http': true,     // http and https requests
-          'pg': true,  // postgresql queries from pg module
       }
 
 .. describe:: maxBreadcrumbs

--- a/lib/breadcrumbs.js
+++ b/lib/breadcrumbs.js
@@ -113,20 +113,6 @@ var wrappers = {
         return req;
       };
     }, originals);
-  },
-
-  pg: function (Raven) {
-    // Using fill helper here is hard because of `this` binding
-    var pg = require('pg');
-    var origQuery = pg.Connection.prototype.query;
-    pg.Connection.prototype.query = function (text) {
-      Raven.captureBreadcrumb({
-        category: 'postgres',
-        message: text
-      });
-      origQuery.call(this, text);
-    };
-    originals.push([pg.Connection.prototype, 'query', origQuery]);
   }
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -56,7 +56,6 @@ extend(Raven.prototype, {
     var autoBreadcrumbDefaults = {
       console: false,
       http: false,
-      pg: false
     };
     // default to 30, don't allow higher than 100
     this.maxBreadcrumbs = Math.max(0, Math.min(options.maxBreadcrumbs || 30, 100));


### PR DESCRIPTION
Since we're publishing 2.0.0 we can do this for temporary relief for #254, as discussed privately.

/cc @MaxBittker @benvinegar 