### PR TITLE
use cache in parseStack, prevent unnecessary reading of files

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@ var transports = require('./transports');
 var path = require('path');
 var lsmod = require('lsmod');
 var stacktrace = require('stack-trace');
+var Promise = require('promise/domains');
 
 var ravenVersion = require('../package.json').version;
 
@@ -147,6 +148,14 @@ function parseLines(lines, frame) {
   frame.post_context = lines.slice(frame.lineno, frame.lineno + LINES_OF_CONTEXT);
 }
 
+function readFilePromise(filename) {
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filename, function (err, file) {
+      return err ? reject(err) : resolve(file);
+    });
+  });
+}
+
 function parseStack(err, cb) {
   var frames = [],
       cache = {};
@@ -195,16 +204,17 @@ function parseStack(err, cb) {
       return;
     }
 
-    if (frame.filename in cache) {
-      parseLines(cache[frame.filename], frame);
-      if (--callbacks === 0) cb(frames);
-      return;
+    if (!cache[frame.filename]) {
+      cache[frame.filename] = readFilePromise(frame.filename)
+        .then(function (file) {
+          return file.toString().split('\n');
+        }, function () {
+          return null;
+        });
     }
 
-    fs.readFile(frame.filename, function (_err, file) {
-      if (!_err) {
-        file = file.toString().split('\n');
-        cache[frame.filename] = file;
+    cache[frame.filename].then(function (file) {
+      if (file) {
         parseLines(file, frame);
       }
       frames[index] = frame;

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "cookie": "0.3.1",
     "json-stringify-safe": "5.0.1",
     "lsmod": "1.0.0",
-    "uuid": "3.0.0",
+    "promise": "^7.1.1",
     "stack-trace": "0.0.9",
-    "timed-out": "4.0.1"
+    "timed-out": "4.0.1",
+    "uuid": "3.0.0"
   },
   "devDependencies": {
     "coffee-script": "~1.10.0",


### PR DESCRIPTION
`cache` not used in `parseStack`
-  use cache in parseStack, prevent unnecessary reading of files 