### PR TITLE
Parsestack refactor + tests to fix memory leak

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 coverage/
 test/instrumentation/node-*
+test/manual/largeModule.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,4 @@ node_js:
   - "5"
   - "6"
   - "7"
-before_install:
-  - "npm install --upgrade npm -g"
 script: npm run test-full

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,6 @@ var transports = require('./transports');
 var path = require('path');
 var lsmod = require('lsmod');
 var stacktrace = require('stack-trace');
-var Promise = require('promise/domains');
 
 var ravenVersion = require('../package.json').version;
 
@@ -142,52 +141,46 @@ function getModule(filename, base) {
   return file;
 }
 
-function parseLines(lines, frame) {
-  frame.pre_context = lines.slice(Math.max(0, frame.lineno - (LINES_OF_CONTEXT + 1)), frame.lineno - 1);
-  frame.context_line = lines[frame.lineno - 1];
-  frame.post_context = lines.slice(frame.lineno, frame.lineno + LINES_OF_CONTEXT);
-}
+function readSourceFiles(filenames, cb) {
+  // we're relying on filenames being de-duped already
+  if (filenames.length === 0) return setTimeout(cb, 0, {});
 
-function readFilePromise(filename) {
-  return new Promise(function (resolve, reject) {
-    fs.readFile(filename, function (err, file) {
-      return err ? reject(err) : resolve(file);
+  var sourceFiles = {};
+  var numFilesToRead = filenames.length;
+  return filenames.forEach(function (filename) {
+    fs.readFile(filename, function (readErr, file) {
+      if (!readErr) sourceFiles[filename] = file.toString().split('\n');
+      if (--numFilesToRead === 0) cb(sourceFiles);
     });
   });
 }
 
 function parseStack(err, cb) {
-  var frames = [],
-      cache = {};
-
-  if (!err) {
-    return cb(frames);
-  }
+  if (!err) return cb([]);
 
   var stack = stacktrace.parse(err);
-
-  // check to make sure that the stack is what we need it to be.
   if (!stack || !Array.isArray(stack) || !stack.length || !stack[0].getFileName) {
-    // lol, stack is fucked
-    return cb(frames);
+    // the stack is not the useful thing we were expecting :/
+    return cb([]);
   }
 
-  var callbacks = stack.length;
-
-  // Sentry requires the stack trace to be from oldest to newest
+  // Sentry expects the stack trace to be oldest -> newest, v8 provides newest -> oldest
   stack.reverse();
 
-  return stack.forEach(function (line, index) {
+  var frames = [];
+  var filesToRead = {};
+  stack.forEach(function (line) {
     var frame = {
-          filename: line.getFileName() || '',
-          lineno: line.getLineNumber(),
-          colno: line.getColumnNumber(),
-          'function': getFunction(line),
-        },
-        isInternal = line.isNative() ||
-          frame.filename[0] !== '/' &&
-          frame.filename[0] !== '.' &&
-          frame.filename.indexOf(':\\') !== 1;
+      filename: line.getFileName() || '',
+      lineno: line.getLineNumber(),
+      colno: line.getColumnNumber(),
+      'function': getFunction(line),
+    };
+
+    var isInternal = line.isNative() ||
+      frame.filename[0] !== '/' &&
+      frame.filename[0] !== '.' &&
+      frame.filename.indexOf(':\\') !== 1;
 
     // in_app is all that's not an internal Node function or a module within node_modules
     // note that isNative appears to return true even for node core libraries
@@ -195,31 +188,30 @@ function parseStack(err, cb) {
     frame.in_app = !isInternal && frame.filename.indexOf('node_modules/') === -1;
 
     // Extract a module name based on the filename
-    if (frame.filename) frame.module = getModule(frame.filename);
-
-    // internal Node files are not full path names. Ignore them.
-    if (isInternal) {
-      frames[index] = frame;
-      if (--callbacks === 0) cb(frames);
-      return;
+    if (frame.filename) {
+      frame.module = getModule(frame.filename);
+      if (!isInternal) filesToRead[frame.filename] = true;
     }
 
-    if (!cache[frame.filename]) {
-      cache[frame.filename] = readFilePromise(frame.filename)
-        .then(function (file) {
-          return file.toString().split('\n');
-        }, function () {
-          return null;
-        });
-    }
+    frames.push(frame);
+  });
 
-    cache[frame.filename].then(function (file) {
-      if (file) {
-        parseLines(file, frame);
+  return readSourceFiles(Object.keys(filesToRead), function (sourceFiles) {
+    frames.forEach(function (frame) {
+      if (frame.filename && sourceFiles[frame.filename]) {
+        var lines = sourceFiles[frame.filename];
+        try {
+          frame.pre_context = lines.slice(Math.max(0, frame.lineno - (LINES_OF_CONTEXT + 1)), frame.lineno - 1);
+          frame.context_line = lines[frame.lineno - 1];
+          frame.post_context = lines.slice(frame.lineno, frame.lineno + LINES_OF_CONTEXT);
+        } catch (e) {
+          // anomaly, being defensive in case
+          // unlikely to ever happen in practice but can definitely happen in theory
+        }
       }
-      frames[index] = frame;
-      if (--callbacks === 0) cb(frames);
     });
+
+    cb(frames);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "cookie": "0.3.1",
     "json-stringify-safe": "5.0.1",
     "lsmod": "1.0.0",
-    "promise": "^7.1.1",
     "stack-trace": "0.0.9",
     "timed-out": "4.0.1",
     "uuid": "3.0.0"

--- a/test/manual/express-patient.js
+++ b/test/manual/express-patient.js
@@ -114,6 +114,24 @@ app.get('/capture', function (req, res, next) {
   next();
 });
 
+app.get('/capture_large_source', function (req, res, next) {
+  nockRequest();
+
+  // largeModule.run recurses 1000 times, largeModule is a 5MB file
+  // if we read the largeModule source once for each frame, we'll use a ton of memory
+  var largeModule = require('./largeModule');
+
+  try {
+    largeModule.run();
+  } catch (e) {
+    Raven.captureException(e);
+  }
+
+  memwatch.gc();
+  res.textToSend = 'capturing an exception!';
+  next();
+});
+
 app.use(function (req, res, next) {
   if (req.query.doError) {
     nockRequest();

--- a/test/manual/poke-patient.sh
+++ b/test/manual/poke-patient.sh
@@ -19,6 +19,11 @@ curl localhost:3000/capture
 gc
 gc_restart
 
+curl localhost:3000/capture_large_source
+gc
+gc
+gc_restart
+
 ab -c 5 -n 5000 localhost:3000/hello
 gc_restart
 

--- a/test/raven.utils.js
+++ b/test/raven.utils.js
@@ -192,6 +192,7 @@ describe('raven.utils', function () {
         });
         filesRead.length.should.equal(uniqueFilesRead.length);
 
+        fs.readFile = origReadFile;
         done();
       }
 


### PR DESCRIPTION
Fixes #319, based on the insight in #318; thanks to @asuka999 for the original insight + PR and @cveilleux for the memory leak report.

- refactors `parseStack`into a more serial-procedural style with a `readSourceFiles` helper
- adds a unit test to check that readFile is only called once per file
- adds a manual memory test for capturing an error thrown from 1000-deep callstack in a 5MB file 
  - without this fix, parsing that stack and reading it multiple times concurrently would run the node process out of memory

The parseStack code in general needed some overhauling, so I went ahead and did that in addition to just fixing the concurrency control flow. It should hopefully be more robust and easier to follow now.

/cc @MaxBittker @benvinegar 