### PR TITLE
Update Node flags for v8.X instrumentation tests

### DIFF
--- a/test/instrumentation/run.sh
+++ b/test/instrumentation/run.sh
@@ -7,5 +7,6 @@ if [ ! -d $nodeRoot ]; then
   url="https://codeload.github.com/nodejs/node/tar.gz/$version"
   curl $url -o "$version.tar.gz"
   tar -xf "$version.tar.gz"
+  rm "$version.tar.gz"
 fi
 exec node http.test.js `pwd`/$nodeRoot


### PR DESCRIPTION
Added `--expose-internals` flag to all tests and `--expose-http2` for Node >= 8 only, as it's not supported in previous versions.

Included one edge case, where we have to remove http2 flag, as the test itself is asserting it's absence.