### PR TITLE
Pre Node v4 deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
   - "6"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 
 [![Build Status](https://travis-ci.org/getsentry/raven-node.svg?branch=master)](https://travis-ci.org/getsentry/raven-node)
 
+`raven-node` supports only LTS versions of Node, therefore currently required release is `>= v4.0.0`.
+The last known working version for `v0.10` and `v0.12` is `raven-node@2.1.2`.
+Please use this version if you need to support those releases of Node.
+
+To see up-to-date Node.js LTS Release Schedule, go to https://github.com/nodejs/LTS.
+
 ## Resources
 
 * [Documentation](https://docs.getsentry.com/hosted/clients/node/)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-full": "npm run test && cd test/instrumentation && ./run.sh"
   },
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.0.0"
   },
   "dependencies": {
     "cookie": "0.3.1",

--- a/test/instrumentation/http.test.js
+++ b/test/instrumentation/http.test.js
@@ -3,9 +3,6 @@ var fs = require('fs');
 var path = require('path');
 var child_process = require('child_process');
 
-// running on pre-4.0 is hard, somewhat different test scheme
-if (process.version < 'v4') process.exit(0);
-
 var nodeRoot = process.argv[2];
 var testRoot = path.join(nodeRoot, 'test/parallel');
 var testFiles = fs.readdirSync(testRoot).filter(function (filename) {


### PR DESCRIPTION
Initial PR for dropping support of Node pre v4.

- wrote message about supported LTS versions
- removed `<v4` guard from instrumentation tests
- removed v0.10 and v0.12 from TravisCI config

Related issue: https://github.com/getsentry/raven-node/issues/365