### PR TITLE
fix: Pull Error's name from constructor, not Error itself

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -15,7 +15,8 @@ module.exports.parseText = function parseText(message, kwargs) {
 
 module.exports.parseError = function parseError(err, kwargs, cb) {
   utils.parseStack(err, function(frames) {
-    var name = err.name + '';
+    var name =
+      ({}.hasOwnProperty.call(err, 'name') ? err.name : err.constructor.name) + '';
     if (typeof kwargs.message === 'undefined') {
       kwargs.message = name + ': ' + (err.message || '<no message>');
     }


### PR DESCRIPTION
Fixes: https://github.com/getsentry/raven-node/issues/350