### PR TITLE
fix: attach remaining non-enumerables to req

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -526,19 +526,30 @@ extend(Raven.prototype, {
      * (eg. globalContext.request + domainContext.request + kwargs.request),
      * we manually pull them out from original objects.
      *
+     * Same scenario happens when some frameworks (eg. Koa) decide to use request within
+     * request. eg `this.request.req`, which adds aliases to the main `request` object.
+     * By manually reassigning them here, we don't need to add additional checks
+     * like `req.method || (req.req && req.req.method)`
+     *
      * We don't use Object.assign/extend as it's only merging over objects own properties,
      * and we don't want to go through all of the properties as well, as we simply don't
      * need all of them.
-     *
-     * So far the only missing piece is `ip`, but we can specify what properties should
-     * be pulled by extending `nonEnumerables` array.
      **/
     var sources = Array.from(arguments).filter(function(source) {
       return Object.prototype.toString.call(source) === '[object Object]';
     });
     sources = [{}].concat(sources);
     var request = extend.apply(null, sources);
-    var nonEnumberables = ['ip'];
+    var nonEnumberables = [
+      'headers',
+      'host',
+      'ip',
+      'method',
+      'protocol',
+      'query',
+      'secure',
+      'url'
+    ];
 
     nonEnumberables.forEach(function(key) {
       sources.forEach(function(source) {


### PR DESCRIPTION
Ref: https://github.com/getsentry/raven-node/issues/375

An issue here is that Koa wraps request object, and those properties are not enumerable – https://github.com/koajs/koa/blob/master/docs/api/request.md

`bodyparser` middleware, attaches body to `this.request` object, not `this.req`, therefore we have to use former as the context for the error and we cannot just say `this.request.req` while calling it, eg.

```js
Raven.captureException(err, {
  req: this.request.req,
}, (sendErr, eventId) => {
  if (sendErr) console.error('Failed to send captured exception to Sentry', err);
});
```

This will work, but will skip the `body` of a request, which we definitely don't want.