### PR TITLE
feat: Allow to configure stacktrace for captureMessage calls

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -234,6 +234,10 @@ Those configuration options are documented below:
 
   Controls how many requests can be maximally queued before bailing out and emitting an error. Defaults to `100`.
 
+.. describe:: stacktrace
+
+  Attack stack trace to `captureMessage` calls by generatic "synthetic" error object and extracting all frames.
+
 Environment Variables
 ---------------------
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -70,6 +70,7 @@ extend(Raven.prototype, {
     this.sampleRate = typeof options.sampleRate === 'undefined' ? 1 : options.sampleRate;
     this.maxReqQueueCount = options.maxReqQueueCount || 100;
     this.parseUser = options.parseUser;
+    this.stacktrace = options.stacktrace || false;
 
     if (!this.dsn) {
       utils.consoleAlert('no DSN provided, error reporting disabled');
@@ -229,7 +230,7 @@ extend(Raven.prototype, {
       but also want to provide convenience for passing a req object and having us parse it out
       so we only parse a `req` property if the `request` property is absent/empty (and hence we won't clobber)
       parseUser returns a partial kwargs object with a `request` property and possibly a `user` property
-    */
+      */
     kwargs.request = this._createRequestObject(
       this._globalContext.request,
       domainContext.request,
@@ -318,8 +319,31 @@ extend(Raven.prototype, {
     } else {
       kwargs = kwargs || {};
     }
+
     var eventId = this.generateEventId();
-    this.process(eventId, parsers.parseText(message, kwargs), cb);
+
+    if (this.stacktrace) {
+      var ex;
+      // Generate a "synthetic" stack trace
+      try {
+        throw new Error(message);
+      } catch (ex1) {
+        ex = ex1;
+      }
+
+      utils.parseStack(
+        ex,
+        function(frames) {
+          // We trim last frame, as it's our `throw new Error(message)` call itself, which is redundant
+          kwargs.stacktrace = {
+            frames: frames.slice(0, -1)
+          };
+          this.process(eventId, parsers.parseText(message, kwargs), cb);
+        }.bind(this)
+      );
+    } else {
+      this.process(eventId, parsers.parseText(message, kwargs), cb);
+    }
 
     return eventId;
   },

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -199,6 +199,21 @@ describe('raven.Client', function() {
 
       client.captureMessage('Hey!');
     });
+
+    it('should allow for attaching stacktrace', function(done) {
+      var dsn = 'https://public:private@app.getsentry.com:8443/269';
+      var client = new raven.Client(dsn, {
+        stacktrace: true
+      });
+      client.send = function mockSend(kwargs) {
+        kwargs.message.should.equal('wtf?');
+        kwargs.should.have.property('stacktrace');
+        var stack = kwargs.stacktrace;
+        stack.frames[stack.frames.length - 1].context_line.should.match(/captureMessage/);
+        done();
+      };
+      client.captureMessage('wtf?');
+    });
   });
 
   describe('#captureException()', function() {


### PR DESCRIPTION
Ref https://github.com/getsentry/raven-node/issues/332

Stack trace example:
![screen shot 2017-10-05 at 16 36 03](https://user-images.githubusercontent.com/1523305/31232974-a6e7d4a0-a9eb-11e7-82d7-8d9d292ac059.png)


Removed frame (https://github.com/getsentry/raven-node/compare/message-stacktrace?expand=1#diff-50cfa59973c04321b5da0c6da0fdf4feR337):
![screen shot 2017-10-05 at 16 35 59](https://user-images.githubusercontent.com/1523305/31232871-5ed6bcda-a9eb-11e7-9b04-3ff4bfb15733.png)
