### PR TITLE
fix: access 'process' through global variable

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -37,25 +37,25 @@ extend(Raven.prototype, {
 
     if (arguments.length === 0) {
       // no arguments, use default from environment
-      dsn = process.env.SENTRY_DSN;
+      dsn = global.process.env.SENTRY_DSN;
       options = {};
     }
     if (typeof dsn === 'object') {
       // They must only be passing through options
       options = dsn;
-      dsn = process.env.SENTRY_DSN;
+      dsn = global.process.env.SENTRY_DSN;
     }
     options = options || {};
 
     this.raw_dsn = dsn;
     this.dsn = utils.parseDSN(dsn);
-    this.name = options.name || process.env.SENTRY_NAME || require('os').hostname();
-    this.root = options.root || process.cwd();
+    this.name = options.name || global.process.env.SENTRY_NAME || require('os').hostname();
+    this.root = options.root || global.process.cwd();
     this.transport = options.transport || transports[this.dsn.protocol];
     this.sendTimeout = options.sendTimeout || 1;
-    this.release = options.release || process.env.SENTRY_RELEASE || '';
+    this.release = options.release || global.process.env.SENTRY_RELEASE || '';
     this.environment =
-      options.environment || process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || '';
+      options.environment || global.process.env.SENTRY_ENVIRONMENT || global.process.env.NODE_ENV || '';
 
     // autoBreadcrumbs: true enables all, autoBreadcrumbs: false disables all
     // autoBreadcrumbs: { http: true } enables a single type
@@ -94,7 +94,7 @@ extend(Raven.prototype, {
 
     this.onFatalError = this.defaultOnFatalError = function(err, sendErr, eventId) {
       console.error(err && err.stack ? err.stack : err);
-      process.exit(1);
+      global.process.exit(1);
     };
     this.uncaughtErrorHandler = this.makeErrorHandler();
 
@@ -112,11 +112,11 @@ extend(Raven.prototype, {
       this.onFatalError = cb;
     }
 
-    process.on('uncaughtException', this.uncaughtErrorHandler);
+    global.process.on('uncaughtException', this.uncaughtErrorHandler);
 
     if (this.captureUnhandledRejections) {
       var self = this;
-      process.on('unhandledRejection', function(reason) {
+      global.process.on('unhandledRejection', function(reason) {
         self.captureException(reason, function(sendErr, eventId) {
           if (!sendErr) utils.consoleAlert('unhandledRejection captured: ' + eventId);
         });
@@ -136,8 +136,8 @@ extend(Raven.prototype, {
     instrumentor.deinstrument(this);
 
     // todo: this works for tests for now, but isn't what we ultimately want to be doing
-    process.removeAllListeners('uncaughtException');
-    process.removeAllListeners('unhandledRejection');
+    global.process.removeAllListeners('uncaughtException');
+    global.process.removeAllListeners('unhandledRejection');
 
     this.installed = false;
 
@@ -252,8 +252,8 @@ extend(Raven.prototype, {
     kwargs.modules = utils.getModules();
     kwargs.server_name = kwargs.server_name || this.name;
 
-    if (typeof process.version !== 'undefined') {
-      kwargs.extra.node = process.version;
+    if (typeof global.process.version !== 'undefined') {
+      kwargs.extra.node = global.process.version;
     }
 
     kwargs.environment = kwargs.environment || this.environment;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -132,7 +132,7 @@ function getFunction(line) {
 
 var mainModule =
   ((require.main && require.main.filename && path.dirname(require.main.filename)) ||
-    process.cwd()) + '/';
+    global.process.cwd()) + '/';
 
 function getModule(filename, base) {
   if (!base) base = mainModule;

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -268,6 +268,8 @@ describe('raven.Client', function() {
         zlib.deflate = old;
 
         var kwargs = JSON.parse(skwargs);
+        // Remove superfluous node version data to simplify the test itself
+        delete kwargs.extra.node;
         kwargs.should.have.property('extra', {
           foo: '[Circular ~]'
         });


### PR DESCRIPTION
This fixes correct code behavior when bundled using webpack. Otherwise, our bundled SDK will always yield `undefined` for anything we want to read from `process` variable.

And we do need to access it to gather environment information like `node` version.

Related: https://github.com/getsentry/sentry/pull/6626