### PR TITLE
ref: Enable http instrumentation by default

### DIFF
--- a/lib/instrumentation/instrumentor.js
+++ b/lib/instrumentation/instrumentor.js
@@ -3,7 +3,8 @@
 var utils = require('../utils');
 
 var defaultOnConfig = {
-  console: true
+  console: true,
+  http: true
 };
 
 var defaultConfig = {


### PR DESCRIPTION
It was omitted by an accident when refactoring a looong time ago.
This change won't break anything, however, not everyone might want to turn this instrumentation on.
On the other hand, it's so minor change, that I don't believe it should wait for the new major release. WDYT?