### PR TITLE
ref: Warn user when using capture/wrap without installing Raven

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -49,13 +49,17 @@ extend(Raven.prototype, {
 
     this.raw_dsn = dsn;
     this.dsn = utils.parseDSN(dsn);
-    this.name = options.name || global.process.env.SENTRY_NAME || require('os').hostname();
+    this.name =
+      options.name || global.process.env.SENTRY_NAME || require('os').hostname();
     this.root = options.root || global.process.cwd();
     this.transport = options.transport || transports[this.dsn.protocol];
     this.sendTimeout = options.sendTimeout || 1;
     this.release = options.release || global.process.env.SENTRY_RELEASE || '';
     this.environment =
-      options.environment || global.process.env.SENTRY_ENVIRONMENT || global.process.env.NODE_ENV || '';
+      options.environment ||
+      global.process.env.SENTRY_ENVIRONMENT ||
+      global.process.env.NODE_ENV ||
+      '';
 
     // autoBreadcrumbs: true enables all, autoBreadcrumbs: false disables all
     // autoBreadcrumbs: { http: true } enables a single type
@@ -385,6 +389,11 @@ extend(Raven.prototype, {
   },
 
   wrap: function(options, func) {
+    if (!this.installed) {
+      utils.consoleAlertOnce(
+        'Raven has not been installed, therefore no breadcrumbs will be captured. Call `Raven.config(...).install()` to fix this.'
+      );
+    }
     if (!func && typeof options === 'function') {
       func = options;
       options = {};


### PR DESCRIPTION
Ref: https://github.com/getsentry/raven-node/issues/396

I don't want to change breadcrumbs behaviour right now, therefore this is the least obtrusive solution.