### PR TITLE
ci: Integrate Zeus and release with the bot

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+store: zeus
+targets:
+  - name: github
+    changelog: History.md
+  - npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-branches:
-  only:
-    - master
 sudo: false
 language: node_js
 node_js:
@@ -9,7 +6,31 @@ node_js:
   - "6"
   - "7"
   - "8"
+
 cache:
   directories:
     - node_modules
+
+branches:
+  only:
+    - master
+
 script: npm run test-full
+
+matrix:
+  include:
+    - script: npm pack
+      node_js: "8"
+      after_success:
+        - npm install -g @zeus-ci/cli
+        - zeus upload -t "application/tar+npm" *.tgz
+
+notifications:
+  webhooks:
+    urls:
+      - https://zeus.ci/hooks/b152d48c-d694-11e7-99e7-0a580a28020f/public/provider/travis/webhook
+    on_success: always
+    on_failure: always
+    on_start: always
+    on_cancel: always
+    on_error: always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,9 @@
 ## How to release raven-node:
-  * [ ] Run the manual memory tests in `test/manual` to make sure we didn't introduce a memory leak
-    * [ ] Consider whether any changes warrant additions to these tests
-  * [ ] Stop and think "What version number should this be according to SemVer?"
-  * [ ] Bump version number in `package.json`.
-  * [ ] Add an entry to the [History](https://github.com/getsentry/raven-node/blob/master/History.md) file.
-  * [ ] Commit new version, create a tag (`git tag -a v1.2.3 -m "Version 1.2.3"`). Push to GitHub (`git push --follow-tags`).
-  * [ ] `$ npm publish` to push to npm.
-  * [ ] Verify that `npm install raven@1.2.3` works.
-  * [ ] Copy History entry into a new GH Release: https://github.com/getsentry/raven-node/releases
-  * [ ] glhf
+
+* [ ] Run the manual memory tests in `test/manual` to make sure we didn't introduce a memory leak
+  * [ ] Consider whether any changes warrant additions to these tests
+* [ ] Stop and think "What version number should this be according to SemVer?"
+* [ ] Add an entry to the [History](https://github.com/getsentry/raven-node/blob/master/History.md) file.
+* [ ] Bump version number in `package.json` using `npm version -m 'release: %s'`.
+* [ ] Push to GitHub (`git push origin master --follow-tags`).
+* [ ] Once CI builds pass, `sentry-probot` will publish a release on npm and GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,6 @@
   * [ ] Consider whether any changes warrant additions to these tests
 * [ ] Stop and think "What version number should this be according to SemVer?"
 * [ ] Add an entry to the [History](https://github.com/getsentry/raven-node/blob/master/History.md) file.
-* [ ] Bump version number in `package.json` using `npm version -m 'release: %s'`.
+* [ ] Bump version number in `package.json` using `npm version -m [patch|minor|major] 'release: %s'`.
 * [ ] Push to GitHub (`git push origin master --follow-tags`).
 * [ ] Once CI builds pass, `sentry-probot` will publish a release on npm and GitHub.


### PR DESCRIPTION
This PR enables the release bot via Zeus. Essentially, to push a new release to npm you just have to bump the version and push the tag: 

```sh
$ npm version patch -m "release: %s" # or minor or major
$ git push origin master --follow-tags 
```

After the Travis build succeeds, the bot will download the npm package tarball from Zeus and publish it to npm with its user. The package needs to show up on the [Sentry developers team](https://www.npmjs.com/org/sentry/team/developers) on npm for this to work. 

Also, a release on GitHub is created and automatically gets the changelog from `History.md`. 

Note that coverage and tests are still missing in Zeus. Also beware that once the package goes scoped, `release.yml` also needs to be updated.

<img width="654" alt="screen shot 2017-12-01 at 14 12 50" src="https://user-images.githubusercontent.com/1433023/33484261-cfe084aa-d6a1-11e7-9e28-e9afd7c76ae1.png">