### PR TITLE
feat: Support Boom statusCode

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -522,7 +522,7 @@ extend(Raven.prototype, {
   errorHandler: function() {
     var self = this;
     return function(err, req, res, next) {
-      var status = err.status || err.statusCode || err.status_code || 500;
+      var status = err.status || err.statusCode || err.status_code || err.output && err.output.statusCode || 500;
 
       // skip anything not marked as an internal server error
       if (status < 500) return next(err);


### PR DESCRIPTION
**What happens?**

raven considers all [Boom](https://github.com/hapijs/boom) errors to be 500 as a Boom error doesn't have statusCode at error root level.

**What should happen?**

raven should try to get the statusCode if error is a Boom error.