### PR TITLE
Fixed express deprecation warning

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -580,9 +580,9 @@ extend(Raven.prototype, {
     });
     sources = [{}].concat(sources);
     var request = extend.apply(null, sources);
-    var nonEnumberables = [
+    var nonEnumerables = [
       'headers',
-      'host',
+      'hostname',
       'ip',
       'method',
       'protocol',
@@ -591,7 +591,7 @@ extend(Raven.prototype, {
       'url'
     ];
 
-    nonEnumberables.forEach(function(key) {
+    nonEnumerables.forEach(function(key) {
       sources.forEach(function(source) {
         if (source[key]) request[key] = source[key];
       });


### PR DESCRIPTION
"express deprecated req.host: Use req.hostname instead" has been fixed