### PR TITLE
fix: workaround for express.js 'host' deprecation message

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -580,9 +580,9 @@ extend(Raven.prototype, {
     });
     sources = [{}].concat(sources);
     var request = extend.apply(null, sources);
-    var nonEnumberables = [
+    var nonEnumerables = [
       'headers',
-      'host',
+      'hostname',
       'ip',
       'method',
       'protocol',
@@ -591,11 +591,23 @@ extend(Raven.prototype, {
       'url'
     ];
 
-    nonEnumberables.forEach(function(key) {
+    nonEnumerables.forEach(function(key) {
       sources.forEach(function(source) {
         if (source[key]) request[key] = source[key];
       });
     });
+
+    /**
+     * Check for 'host' *only* after we checked for 'hostname' first.
+     * This way we can avoid the noise coming from Express deprecation warning
+     * https://github.com/expressjs/express/blob/b97faff6e2aa4d34d79485fe4331cb0eec13ad57/lib/request.js#L450-L452
+     * REF: https://github.com/getsentry/raven-node/issues/96#issuecomment-354748884
+     **/
+    if (!request.hasOwnProperty('hostname')) {
+      sources.forEach(function(source) {
+        if (source.host) request.host = source.host;
+      });
+    }
 
     return request;
   }


### PR DESCRIPTION
Ref: https://github.com/getsentry/raven-node/issues/96#issuecomment-354748884
Ref: https://github.com/getsentry/raven-node/pull/412