### PR TITLE
Fix reporting fatal errors

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -161,7 +161,7 @@ extend(Raven.prototype, {
         // also we want to make sure we don't go recursion crazy if more errors happen after this one
         firstError = err;
         caughtFirstError = true;
-        self.captureException(err, function(sendErr, eventId) {
+        self.captureException(err, {level: 'fatal'}, function(sendErr, eventId) {
           if (!calledFatalError) {
             calledFatalError = true;
             self.onFatalError(err, sendErr, eventId);


### PR DESCRIPTION
## Overview

I have an application in production I noticed was crashing, but never saw any fatal errors sitting in sentry. After digging deeper I found the `uncaughtException` handler doesn't pass a level, so it defaults to `Error`. This PR fixes that.

## Repro

```javascript
const raven = require('raven');

const sentry_dsn = 'INSERT DSN HERE';
const client = raven.Client(sentry_dsn);
client.install();

client.captureException(new Error('This is a regular error'));
throw new Error('This is a fatal error');

console.log('Done'); // Never reached.
```

__Before Fix:__

![screen shot 2018-02-08 at 11 28 39 am](https://user-images.githubusercontent.com/5246169/35984991-99262f2a-0cc3-11e8-8142-7a8502369cc2.png)

__After Fix:__

![screen shot 2018-02-08 at 11 19 22 am](https://user-images.githubusercontent.com/5246169/35985007-9efcf05a-0cc3-11e8-8d54-0da4f9975717.png)
