### PR TITLE
fix: preserve context in for rejected promises

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -120,8 +120,9 @@ extend(Raven.prototype, {
 
     if (this.captureUnhandledRejections) {
       var self = this;
-      global.process.on('unhandledRejection', function(reason) {
-        self.captureException(reason, function(sendErr, eventId) {
+      global.process.on('unhandledRejection', function(reason, promise) {
+        var context = promise.domain && promise.domain.sentryContext;
+        self.captureException(reason, context || {}, function(sendErr, eventId) {
           if (!sendErr) utils.consoleAlert('unhandledRejection captured: ' + eventId);
         });
       });


### PR DESCRIPTION
currently, context is lost in case of an unhandled promise rejection. This fix keeps track of the context by looking into the rejected promise domain. This fix has been tested in my production environment and seems to do the trick there.