### PR TITLE
ref: Use named function for middlewares

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -532,7 +532,7 @@ extend(Raven.prototype, {
 
   requestHandler: function() {
     var self = this;
-    return function ravenMiddleware(req, res, next) {
+    return function ravenRequestMiddleware(req, res, next) {
       self.context({req: req}, function() {
         domain.active.add(req);
         domain.active.add(res);
@@ -543,7 +543,7 @@ extend(Raven.prototype, {
 
   errorHandler: function() {
     var self = this;
-    return function(err, req, res, next) {
+    return function ravenErrorMiddleware(err, req, res, next) {
       var status =
         err.status ||
         err.statusCode ||


### PR DESCRIPTION
Per https://github.com/getsentry/raven-node/commit/51aa43e6cbc1a57471d55b9f52bf8c33bd64b589#commitcomment-27581611