### PR TITLE
fix: allow calling captureException without configuration

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -216,16 +216,12 @@ extend(Raven.prototype, {
     }
 
     var domainContext = (domain.active && domain.active.sentryContext) || {};
-    kwargs.user = extend({}, this._globalContext.user, domainContext.user, kwargs.user);
-    kwargs.tags = extend({}, this._globalContext.tags, domainContext.tags, kwargs.tags);
-    kwargs.extra = extend(
-      {},
-      this._globalContext.extra,
-      domainContext.extra,
-      kwargs.extra
-    );
+    var globalContext = this._globalContext || {};
+    kwargs.user = extend({}, globalContext.user, domainContext.user, kwargs.user);
+    kwargs.tags = extend({}, globalContext.tags, domainContext.tags, kwargs.tags);
+    kwargs.extra = extend({}, globalContext.extra, domainContext.extra, kwargs.extra);
     kwargs.breadcrumbs = {
-      values: domainContext.breadcrumbs || this._globalContext.breadcrumbs || []
+      values: domainContext.breadcrumbs || globalContext.breadcrumbs || []
     };
 
     /*
@@ -237,13 +233,13 @@ extend(Raven.prototype, {
       parseUser returns a partial kwargs object with a `request` property and possibly a `user` property
       */
     kwargs.request = this._createRequestObject(
-      this._globalContext.request,
+      globalContext.request,
       domainContext.request,
       kwargs.request
     );
     if (Object.keys(kwargs.request).length === 0) {
       var req = this._createRequestObject(
-        this._globalContext.req,
+        globalContext.req,
         domainContext.req,
         kwargs.req
       );
@@ -265,7 +261,7 @@ extend(Raven.prototype, {
     kwargs.logger = kwargs.logger || this.loggerName;
     kwargs.event_id = eventId;
     kwargs.timestamp = new Date().toISOString().split('.')[0];
-    kwargs.project = this.dsn.project_id;
+    kwargs.project = this.dsn && this.dsn.project_id;
     kwargs.platform = 'node';
     kwargs.release = this.release;
 

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -373,6 +373,12 @@ describe('raven.Client', function() {
         }
       });
     });
+
+    it('should call callback even without a config', function(done) {
+      raven.captureException(new Error('wtf?'), function(err) {
+        done();
+      });
+    });
   });
 
   describe('#install()', function() {


### PR DESCRIPTION
This prevents a crash when using `captureException` without having configured the client first. See #430 for background. A little unsure if this is the wanted behavior, but better than crashing, I figure.