### PR TITLE
ref: Log promise rejection reason alongside eventid

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -123,7 +123,17 @@ extend(Raven.prototype, {
       global.process.on('unhandledRejection', function(reason, promise) {
         var context = promise.domain && promise.domain.sentryContext;
         self.captureException(reason, context || {}, function(sendErr, eventId) {
-          if (!sendErr) utils.consoleAlert('unhandledRejection captured: ' + eventId);
+          if (!sendErr) {
+            var reasonMessage = (reason && reason.message) || reason;
+            utils.consoleAlert(
+              'unhandledRejection captured\n' +
+                'Event ID: ' +
+                eventId +
+                '\n' +
+                'Reason: ' +
+                reasonMessage
+            );
+          }
         });
       });
     }


### PR DESCRIPTION
Resolves https://github.com/getsentry/raven-node/issues/433

Reason can be any type, so we first check if there's a `message` property from an `Error` object, and if not, we default to the value itself.