### PR TITLE
feat: log non-standard ports in breadcrumbs

### DIFF
--- a/lib/instrumentation/http.js
+++ b/lib/instrumentation/http.js
@@ -19,11 +19,16 @@ module.exports = function(Raven, http, originals) {
     if (typeof options === 'string') {
       this.__ravenBreadcrumbUrl = options;
     } else {
-      this.__ravenBreadcrumbUrl =
-        (options.protocol || '') +
-        '//' +
-        (options.hostname || options.host || '') +
-        (options.path || '/');
+      var protocol = options.protocol || '';
+      var hostname = options.hostname || options.host || '';
+      // Don't log standard :80 (http) and :443 (https) ports to reduce the noise
+      var port =
+        !options.port || options.port === 80 || options.port === 443
+          ? ''
+          : ':' + options.port;
+      var path = options.path || '/';
+
+      this.__ravenBreadcrumbUrl = protocol + '//' + hostname + port + path;
     }
   };
   util.inherits(ClientRequest, OrigClientRequest);


### PR DESCRIPTION
It makes perfect sens for me.

Resolves: https://github.com/getsentry/raven-node/issues/439