### PR TITLE
fix: Do not override context when capturing non-error exceptions

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -331,7 +331,8 @@ extend(Raven.prototype, {
       cb = kwargs;
       kwargs = {};
     } else {
-      kwargs = kwargs || {};
+      // Do not use reference, as we'll modify this object later on
+      kwargs = kwargs ? JSON.parse(stringify(kwargs)) : {};
     }
 
     var eventId = this.generateEventId();
@@ -367,7 +368,8 @@ extend(Raven.prototype, {
       cb = kwargs;
       kwargs = {};
     } else {
-      kwargs = kwargs || {};
+      // Do not use reference, as we'll modify this object later on
+      kwargs = kwargs ? JSON.parse(stringify(kwargs)) : {};
     }
 
     if (!(err instanceof Error)) {
@@ -375,17 +377,15 @@ extend(Raven.prototype, {
         // This will allow us to group events based on top-level keys
         // which is much better than creating new group when any key/value change
         var keys = Object.keys(err).sort();
-        var hash = md5(keys);
         var message =
           'Non-Error exception captured with keys: ' +
           utils.serializeKeysForMessage(keys);
-        var serializedException = utils.serializeException(err);
-
-        kwargs.message = message;
-        kwargs.fingerprint = [hash];
-        kwargs.extra = {
-          __serialized__: serializedException
-        };
+        kwargs = extend(kwargs, {
+          message: message,
+          fingerprint: [md5(keys)],
+          extra: kwargs.extra || {}
+        });
+        kwargs.extra.__serialized__ = utils.serializeException(err);
 
         err = new Error(message);
       } else {


### PR DESCRIPTION
Resolves https://github.com/getsentry/raven-node/issues/442