### PR TITLE
fix: Remove a redundant try-catch block

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -337,18 +337,12 @@ extend(Raven.prototype, {
     var eventId = this.generateEventId();
 
     if (this.stacktrace) {
-      var ex;
-      // Generate a "synthetic" stack trace
-      try {
-        throw new Error(message);
-      } catch (ex1) {
-        ex = ex1;
-      }
+      var ex = new Error(message);
 
       utils.parseStack(
         ex,
         function(frames) {
-          // We trim last frame, as it's our `throw new Error(message)` call itself, which is redundant
+          // We trim last frame, as it's our `new Error(message)` statement itself, which is redundant
           kwargs.stacktrace = {
             frames: frames.slice(0, -1)
           };


### PR DESCRIPTION
`new Error(message)` creates a stack trace. There's no need to throw and catch it.