### PR TITLE
fix: shallow-clone context instead of deep-copy

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -333,8 +333,7 @@ extend(Raven.prototype, {
       cb = kwargs;
       kwargs = {};
     } else {
-      // Do not use reference, as we'll modify this object later on
-      kwargs = kwargs ? JSON.parse(stringify(kwargs)) : {};
+      kwargs = utils.isPlainObject(kwargs) ? extend({}, kwargs) : {};
     }
 
     var eventId = this.generateEventId();
@@ -364,12 +363,7 @@ extend(Raven.prototype, {
       cb = kwargs;
       kwargs = {};
     } else {
-      var req = kwargs && kwargs.req;
-      // Do not use reference, as we'll modify this object later on
-      kwargs = kwargs ? JSON.parse(stringify(kwargs)) : {};
-      // Preserve `req` so we can use some framework's middleware methods
-      // `req` is the only thing that we pass through in `errorHandler`, so we need just that
-      if (req) kwargs.req = req;
+      kwargs = utils.isPlainObject(kwargs) ? extend({}, kwargs) : {};
     }
 
     if (!(err instanceof Error)) {


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-node/issues/451

I'm not sure if this should be `2.5.1` or `2.6.0` though. Thoughts?