### PR TITLE
ref: use console.warn for alerts and store them in Set

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "env": {
     "node": true,
     "mocha": true,
+    "es6": true
   },
   "rules": {
     "block-scoped-var": 2,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,6 +131,10 @@ module.exports.disableConsoleAlerts = function disableConsoleAlerts() {
   consoleAlerts = false;
 };
 
+module.exports.enableConsoleAlerts = function enableConsoleAlerts() {
+  consoleAlerts = new Set();
+};
+
 module.exports.consoleAlert = function consoleAlert(msg) {
   if (consoleAlerts) {
     console.warn('raven@' + ravenVersion + ' alert: ' + msg);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,7 +15,7 @@ var protocolMap = {
   https: 443
 };
 
-var consoleAlerts = {};
+var consoleAlerts = new Set();
 
 // Default Node.js REPL depth
 var MAX_SERIALIZE_EXCEPTION_DEPTH = 3;
@@ -133,14 +133,14 @@ module.exports.disableConsoleAlerts = function disableConsoleAlerts() {
 
 module.exports.consoleAlert = function consoleAlert(msg) {
   if (consoleAlerts) {
-    console.log('raven@' + ravenVersion + ' alert: ' + msg);
+    console.warn('raven@' + ravenVersion + ' alert: ' + msg);
   }
 };
 
 module.exports.consoleAlertOnce = function consoleAlertOnce(msg) {
-  if (consoleAlerts && !(msg in consoleAlerts)) {
-    consoleAlerts[msg] = true;
-    console.log('raven@' + ravenVersion + ' alert: ' + msg);
+  if (consoleAlerts && !consoleAlerts.has(msg)) {
+    consoleAlerts.add(msg);
+    console.warn('raven@' + ravenVersion + ' alert: ' + msg);
   }
 };
 

--- a/test/raven.client.js
+++ b/test/raven.client.js
@@ -11,8 +11,6 @@ var raven = require('../'),
   zlib = require('zlib'),
   child_process = require('child_process');
 
-raven.utils.disableConsoleAlerts();
-
 var dsn = 'https://public:private@app.getsentry.com/269';
 
 var _oldConsoleWarn = console.warn;
@@ -43,6 +41,12 @@ describe('raven.Client', function() {
   var client;
   beforeEach(function() {
     client = new raven.Client(dsn);
+    raven.utils.disableConsoleAlerts();
+  });
+
+  afterEach(function() {
+    client = new raven.Client(dsn);
+    raven.utils.enableConsoleAlerts();
   });
 
   it('should parse the DSN with options', function() {


### PR DESCRIPTION
Resolves https://github.com/getsentry/raven-node/issues/454

I totally agree that it should be piped to stderr, and not stdout, as those are always "something went wrong" alerts.

Also Set is supported since Node 4, which is our lowest supported version https://node.green/#ES2015-built-ins-Set.

