### PR TITLE
ref: Emit transaction instead of culprit

### DIFF
--- a/bin/raven
+++ b/bin/raven
@@ -46,7 +46,7 @@ try {
     message: 'This is a test message generated using ``raven test``',
     level: 'info',
     logger: 'sentry.test',
-    culprit: 'bin:raven at main',
+    transaction: 'bin:raven at main',
     request: {
       method: 'GET',
       url: 'http://example.com'

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -45,10 +45,12 @@ module.exports.parseError = function parseError(err, kwargs, cb) {
       kwargs.extra[name] = extraErrorProps;
     }
 
-    for (var n = frames.length - 1; n >= 0; n--) {
-      if (frames[n].in_app) {
-        kwargs.culprit = kwargs.culprit || utils.getCulprit(frames[n]);
-        break;
+    if (!kwargs.transaction && !kwargs.culprit) {
+      for (var n = frames.length - 1; n >= 0; n--) {
+        if (frames[n].in_app) {
+          kwargs.transaction = utils.getTransaction(frames[n]);
+          break;
+        }
       }
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -206,7 +206,7 @@ module.exports.parseDSN = function parseDSN(dsn) {
   }
 };
 
-module.exports.getCulprit = function getCulprit(frame) {
+module.exports.getTransaction = function getTransaction(frame) {
   if (frame.module || frame.function) {
     return (frame.module || '?') + ' at ' + (frame.function || '?');
   }

--- a/test/raven.parsers.js
+++ b/test/raven.parsers.js
@@ -561,6 +561,23 @@ describe('raven.parsers', function() {
       }
     });
 
+    it('should allow specifying a custom `transaction`', function(done) {
+      try {
+        throw new Error('Foobar');
+      } catch (e) {
+        raven.parsers.parseError(
+          e,
+          {
+            transaction: 'foobar'
+          },
+          function(parsed) {
+            parsed.transaction.should.equal('foobar');
+            done();
+          }
+        );
+      }
+    });
+
     it('should have a string stack after parsing', function(done) {
       try {
         throw new Error('Derp');

--- a/test/raven.utils.js
+++ b/test/raven.utils.js
@@ -309,14 +309,14 @@ describe('raven.utils', function() {
     });
   });
 
-  describe('#getCulprit()', function() {
+  describe('#getTransaction()', function() {
     it('should handle empty', function() {
-      raven.utils.getCulprit({}).should.eql('<unknown>');
+      raven.utils.getTransaction({}).should.eql('<unknown>');
     });
 
     it('should handle missing module', function() {
       raven.utils
-        .getCulprit({
+        .getTransaction({
           function: 'foo'
         })
         .should.eql('? at foo');
@@ -324,7 +324,7 @@ describe('raven.utils', function() {
 
     it('should handle missing function', function() {
       raven.utils
-        .getCulprit({
+        .getTransaction({
           module: 'foo'
         })
         .should.eql('foo at ?');
@@ -332,7 +332,7 @@ describe('raven.utils', function() {
 
     it('should work', function() {
       raven.utils
-        .getCulprit({
+        .getTransaction({
           module: 'foo',
           function: 'bar'
         })


### PR DESCRIPTION
By default, we emit a `transaction` now instead of the culprit. 