### PR TITLE
enable captureUnhandledRejections by default

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -67,7 +67,7 @@ extend(Raven.prototype, {
     // default to 30, don't allow higher than 100
     this.maxBreadcrumbs = Math.max(0, Math.min(options.maxBreadcrumbs || 30, 100));
 
-    this.captureUnhandledRejections = options.captureUnhandledRejections;
+    this.captureUnhandledRejections = options.captureUnhandledRejections === false ? false : true;
     this.loggerName = options.logger;
     this.dataCallback = options.dataCallback;
     this.shouldSendCallback = options.shouldSendCallback;


### PR DESCRIPTION
enable captureUnhandledRejections by default to match the raven-js clients behaviour documented here: https://docs.sentry.io/clients/javascript/config/

captureUnhandledRejections
By default, Raven captures all unhandled promise rejections using standard unhandledrejection event. If you want to disable this behaviour, set this option to false.